### PR TITLE
Upgrade Gale to Paper 26.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,21 @@ out/
 # other stuff
 run/
 
-gale-server
-gale-api
+gale-server/.gradle/
+gale-server/build/
+gale-server/classes/
+gale-server/generated/
+gale-server/libs/
+gale-server/tmp/
+gale-server/src/minecraft/
+gale-api/.gradle/
+gale-api/build/
+gale-api/classes/
+gale-api/generated/
+gale-api/libs/
+gale-api/tmp/
 
+paper-api/
+paper-server/
 
 !gradle/wrapper/gradle-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -2,27 +2,22 @@
 <div align="center">
   <h1>Gale</h1>
   <h3>A Minecraft server fork of <a href="https://github.com/PaperMC/Paper">Paper</a></h3>
-  <h5><i>In active testing - reporting any issues you encounter is highly appreciated!</i></h5>
+  <h5><i>Minecraft 1.21.4 (Paper 26.2) - Port in progress</i></h5>
 
 [![Discord](https://img.shields.io/discord/1045402468416233592?color=5865F2&label=discord&style=for-the-badge)](https://discord.com/invite/gwezNT8c24)
 </div>
 
 ## About
 
-Gale is a fork of [Paper](https://github.com/PaperMC/Paper). It is intended to provide strong performance.
-The project is in open alpha.
+Gale is a fork of [Paper](https://github.com/PaperMC/Paper) focused on reliable performance.
+Currently being ported to Minecraft 1.21.4 (Paper 26.2).
 
 ## Current features
 
-* **Faster threading system**\
-  Gale comes with a custom threading system, that immediately makes terrain generation 2-3x faster than Paper on most systems!\
-  (this is up to 1.19 only, working on rewriting it to 1.20 too but there were some chunk system changes related to Folia, my apologies)
 * **Micro-optimizations**\
-  A number of micro-optimizations that do not change game mechanics from other projects, such as [Airplane](https://github.com/TECHNOVE/Airplane) and [Lithium](https://github.com/CaffeineMC/lithium-fabric), are also included. Every included optimization has been carefully tested and reviewed line-by-line; faulty or risky optimizations will not be added.
-* **Fixes and options**\
-  Gale contains fixes for a few small Minecraft bugs from [Purpur](https://github.com/PurpurMC/Purpur), options to disable some console logs, the option to re-enable sand duping, and more. Every change is fully configurable, and can always be set to Paper behavior.
-* **Variable entity wake-up**\
-  Waking up inactive entities happens spread over time, instead of many entities at once, which makes entities feel and behave more natural.
+  Carefully reviewed optimizations that do not change game mechanics. Every patch is verified line-by-line before inclusion.
+* **Branding**\
+  Server identifies as Gale, with appropriate branding in console, watchdog, and version output.
 
 ## Contributing
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,45 +1,20 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import io.papermc.paperweight.util.path
-import org.gradle.configurationcache.extensions.capitalized
-import kotlin.io.path.deleteRecursively
 
 plugins {
-    java
     `maven-publish`
-    id("com.github.johnrengelman.shadow") version "8.1.1" apply false
-    id("io.papermc.paperweight.patcher") version "1.5.5--SNAPSHOT"
-}
-
-allprojects {
-    apply(plugin = "java")
-    apply(plugin = "maven-publish")
-
-    java {
-        toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
-        }
-    }
+    id("io.papermc.paperweight.patcher") version "2.0.0-beta.21"
 }
 
 val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"
 
 subprojects {
-    tasks.withType<JavaCompile>().configureEach {
-        options.encoding = Charsets.UTF_8.name()
-        options.release.set(17)
-    }
-    tasks.withType<Javadoc> {
-        options.encoding = Charsets.UTF_8.name()
-    }
-    tasks.withType<ProcessResources> {
-        filteringCharset = Charsets.UTF_8.name()
-    }
-    tasks.withType<Test> {
-        testLogging {
-            showStackTraces = true
-            exceptionFormat = TestExceptionFormat.FULL
-            events(TestLogEvent.STANDARD_OUT)
+    apply(plugin = "java-library")
+    apply(plugin = "maven-publish")
+
+    extensions.configure<JavaPluginExtension> {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(25)
         }
     }
 
@@ -47,94 +22,40 @@ subprojects {
         mavenCentral()
         maven(paperMavenPublicUrl)
     }
-}
 
-repositories {
-    mavenCentral()
-    maven(paperMavenPublicUrl) {
-        content {
-            onlyForConfigurations(configurations.paperclip.name)
+    tasks.withType<JavaCompile>().configureEach {
+        options.encoding = Charsets.UTF_8.name()
+        options.release = 25
+    }
+    tasks.withType<Javadoc>().configureEach {
+        options.encoding = Charsets.UTF_8.name()
+    }
+    tasks.withType<ProcessResources>().configureEach {
+        filteringCharset = Charsets.UTF_8.name()
+    }
+    tasks.withType<Test>().configureEach {
+        testLogging {
+            showStackTraces = true
+            exceptionFormat = TestExceptionFormat.FULL
+            events(TestLogEvent.STANDARD_OUT)
         }
     }
-}
-
-dependencies {
-    remapper("net.fabricmc:tiny-remapper:0.8.6:fat")
-    decompiler("net.minecraftforge:forgeflower:2.0.627.2")
-    paperclip("io.papermc:paperclip:3.0.3")
 }
 
 paperweight {
-    serverProject.set(project(":gale-server")) // Gale - build changes
+    upstreams.paper {
+        ref = providers.gradleProperty("paperCommit")
 
-    remapRepo.set(paperMavenPublicUrl)
-    decompileRepo.set(paperMavenPublicUrl)
-
-    usePaperUpstream(providers.gradleProperty("paperRef")) {
-        withPaperPatcher {
-            apiPatchDir.set(layout.projectDirectory.dir("patches/api"))
-            apiOutputDir.set(layout.projectDirectory.dir("gale-api")) // Gale - build changes
-
-            serverPatchDir.set(layout.projectDirectory.dir("patches/server"))
-            serverOutputDir.set(layout.projectDirectory.dir("gale-server")) // Gale - build changes
+        patchFile {
+            path = "paper-api/build.gradle.kts"
+            outputFile = file("gale-api/build.gradle.kts")
+            patchFile = file("gale-api/build.gradle.kts.patch")
+        }
+        patchDir("paperApi") {
+            upstreamPath = "paper-api"
+            excludes = setOf("build.gradle.kts")
+            patchesDir = file("gale-api/paper-patches")
+            outputDir = file("paper-api")
         }
     }
 }
-
-// Uncomment while updating for a new Minecraft version
-//tasks.withType<io.papermc.paperweight.tasks.CollectATsFromPatches> {
-//    extraPatchDir.set(layout.projectDirectory.dir("patches/unapplied/server"))
-//}
-// tasks.withType<io.papermc.paperweight.tasks.RebuildGitPatches> {
-//     filterPatches.set(false)
-// }
-
-tasks.register("printMinecraftVersion") {
-    doLast {
-        println(providers.gradleProperty("mcVersion").get().trim())
-    }
-}
-
-tasks.register("printGaleVersion") { // Gale - branding changes
-    doLast {
-        println(project.version)
-    }
-}
-
-// Gale start - branding changes - package license into jar
-for (classifier in arrayOf("mojmap", "reobf")) {
-    // Based on io.papermc.paperweight.taskcontainers.BundlerJarTasks
-    tasks.named("create${classifier.capitalized()}PaperclipJar") {
-        doLast {
-
-            // Based on io.papermc.paperweight.taskcontainers.BundlerJarTasks
-            val jarName = listOfNotNull(
-                project.name,
-                "paperclip",
-                project.version,
-                classifier
-            ).joinToString("-") + ".jar"
-
-            // Based on io.papermc.paperweight.taskcontainers.BundlerJarTasks
-            val zipFile = layout.buildDirectory.file("libs/$jarName").path
-
-            val rootDir = io.papermc.paperweight.util.findOutputDir(zipFile)
-
-            try {
-                io.papermc.paperweight.util.unzip(zipFile, rootDir)
-
-                val licenseFileName = "LICENSE.txt"
-                project(":gale-server").projectDir.resolve(licenseFileName).copyTo(rootDir.resolve(licenseFileName).toFile())
-
-                io.papermc.paperweight.util.ensureDeleted(zipFile)
-
-                io.papermc.paperweight.util.zip(rootDir, zipFile)
-            } finally {
-                @OptIn(kotlin.io.path.ExperimentalPathApi::class)
-                rootDir.deleteRecursively()
-            }
-
-        }
-    }
-}
-// Gale end - branding changes - package license into jar

--- a/gale-api/build.gradle.kts
+++ b/gale-api/build.gradle.kts
@@ -1,0 +1,276 @@
+import paper.libs.com.google.gson.Gson
+
+plugins {
+    `java-library`
+    `maven-publish`
+    idea
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+val annotationsVersion = "26.0.2"
+val adventureVersion = "5.1.1"
+val bungeeCordChatVersion = "1.21-R0.2-deprecated+build.21"
+val slf4jVersion = "2.0.17"
+val log4jVersion = "2.26.0"
+
+val apiAndDocs: Configuration by configurations.creating
+configurations.api {
+    extendsFrom(apiAndDocs)
+}
+val javadocSourcepath: Configuration by configurations.creating {
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType.SOURCES))
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+    }
+}
+
+// Configure mockito agent that is needed in newer Java versions
+val mockitoAgent = configurations.register("mockitoAgent")
+abstract class MockitoAgentProvider : CommandLineArgumentProvider {
+    @get:CompileClasspath
+    abstract val fileCollection: ConfigurableFileCollection
+
+    override fun asArguments(): Iterable<String> {
+        return listOf("-javaagent:" + fileCollection.files.single().absolutePath)
+    }
+}
+
+dependencies {
+    // api dependencies are listed transitively to API consumers
+    api("com.google.guava:guava:33.6.0-jre")
+    api("com.google.code.gson:gson:2.14.0")
+    api("org.yaml:snakeyaml:2.2")
+    api("org.joml:joml:1.10.8") {
+        isTransitive = false // https://github.com/JOML-CI/JOML/issues/352
+    }
+    api("it.unimi.dsi:fastutil:8.5.18")
+    api("org.apache.logging.log4j:log4j-api:$log4jVersion")
+    api("org.slf4j:slf4j-api:$slf4jVersion")
+    api("com.mojang:brigadier:1.3.10")
+
+    // Deprecate bungeecord-chat in favor of adventure
+    api("net.md-5:bungeecord-chat:$bungeeCordChatVersion") {
+        exclude("com.google.guava", "guava")
+    }
+
+    apiAndDocs(platform("net.kyori:adventure-bom:$adventureVersion"))
+    apiAndDocs("net.kyori:adventure-api")
+    apiAndDocs("net.kyori:adventure-key")
+    apiAndDocs("net.kyori:adventure-text-minimessage")
+    apiAndDocs("net.kyori:adventure-text-serializer-gson")
+    apiAndDocs("net.kyori:adventure-text-serializer-legacy")
+    apiAndDocs("net.kyori:adventure-text-serializer-plain")
+    apiAndDocs("net.kyori:adventure-text-logger-slf4j")
+
+    api("org.apache.maven:maven-resolver-provider:3.9.6") // make API dependency for Paper Plugins
+    implementation("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
+    implementation("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
+
+    // Annotations - Slowly migrate to jspecify
+    val annotations = "org.jetbrains:annotations:$annotationsVersion"
+    compileOnly(annotations)
+    testCompileOnly(annotations)
+    javadocSourcepath(annotations) // For adventure-api module requirements
+
+    val checkerQual = "org.checkerframework:checker-qual:3.49.2"
+    compileOnlyApi(checkerQual)
+    testCompileOnly(checkerQual)
+
+    apiAndDocs("org.jspecify:jspecify:1.0.0")
+
+    // Test dependencies
+    testImplementation("org.apache.commons:commons-lang3:3.20.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
+    testImplementation("org.hamcrest:hamcrest:2.2")
+    testImplementation("org.mockito:mockito-core:5.22.0")
+    testImplementation("org.ow2.asm:asm-tree:9.9.1")
+    mockitoAgent("org.mockito:mockito-core:5.22.0") { isTransitive = false } // configure mockito agent that is needed in newer java versions
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.3")
+}
+
+val generatedDir: java.nio.file.Path = layout.projectDirectory.dir("src/generated/java").asFile.toPath()
+idea {
+    module {
+        generatedSourceDirs.add(generatedDir.toFile())
+    }
+}
+sourceSets {
+    main {
+        java {
+            srcDir("../paper-api/src/main/java")
+            srcDir("../paper-api/src/generated/java")
+        }
+        resources {
+            srcDir("../paper-api/src/main/resources")
+        }
+    }
+    test {
+        java {
+            srcDir("../paper-api/src/test/java")
+        }
+        resources {
+            srcDir("../paper-api/src/test/resources")
+        }
+    }
+}
+
+val outgoingVariants = arrayOf("runtimeElements", "apiElements", "sourcesElements", "javadocElements")
+val mainCapability = "${project.group}:${project.name}:${project.version}"
+configurations {
+    val outgoing = outgoingVariants.map { named(it) }
+    for (config in outgoing) {
+        config {
+            attributes {
+                attribute(io.papermc.paperweight.util.mainCapabilityAttribute, mainCapability)
+            }
+            outgoing {
+                capability(mainCapability)
+                // Paper-MojangAPI has been merged into Paper-API
+                capability("io.papermc.paper:paper-mojangapi:${project.version}")
+                capability("com.destroystokyo.paper:paper-mojangapi:${project.version}")
+                // Conflict with old coordinates
+                capability("com.destroystokyo.paper:paper-api:${project.version}")
+                capability("org.spigotmc:spigot-api:${project.version}")
+                capability("org.bukkit:bukkit:${project.version}")
+            }
+        }
+    }
+}
+
+configure<PublishingExtension> {
+    publications.create<MavenPublication>("maven") {
+        // For Brigadier API
+        outgoingVariants.forEach {
+            suppressPomMetadataWarningsFor(it)
+        }
+        from(components["java"])
+    }
+}
+
+abstract class GenerateApiVersioningFile : DefaultTask() {
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @get:Input
+    abstract val projectVersion: Property<String>
+
+    @get:Input
+    abstract val apiVersion: Property<String>
+
+    @TaskAction
+    fun generate() {
+        val file = outputFile.get().asFile
+        file.parentFile.mkdirs()
+        val map = mapOf(
+            "version" to projectVersion.get(),
+            "currentApiVersion" to apiVersion.get()
+        )
+        file.writeText(Gson().toJson(map))
+    }
+}
+
+val generateApiVersioningFile = tasks.register<GenerateApiVersioningFile>("generateApiVersioningFile") {
+    outputFile.set(layout.buildDirectory.file("apiVersioning.json"))
+    projectVersion.set(project.version.toString())
+    apiVersion.set(rootProject.providers.gradleProperty("apiVersion"))
+}
+
+tasks.jar {
+    from(generateApiVersioningFile.flatMap { it.outputFile })
+    manifest {
+        attributes(
+            "Automatic-Module-Name" to "org.bukkit"
+        )
+    }
+}
+
+abstract class Services {
+    @get:Inject
+    abstract val fileSystemOperations: FileSystemOperations
+}
+val services = objects.newInstance<Services>()
+
+tasks.withType<Javadoc>().configureEach {
+    val options = options as StandardJavadocDocletOptions
+    options.overview = "src/main/javadoc/overview.html"
+    options.use()
+    options.isDocFilesSubDirs = true
+    options.links(
+        "https://guava.dev/releases/33.6.0-jre/api/docs/",
+        "https://www.javadocs.dev/org.yaml/snakeyaml/2.2/",
+        "https://www.javadocs.dev/org.jetbrains/annotations/$annotationsVersion/",
+        "https://www.javadocs.dev/org.joml/joml/1.10.8/",
+        "https://www.javadocs.dev/com.google.code.gson/gson/2.14.0",
+        "https://jspecify.dev/docs/api/",
+        "https://jd.papermc.io/adventure/$adventureVersion/",
+        "https://www.javadocs.dev/org.slf4j/slf4j-api/$slf4jVersion/",
+        "https://logging.apache.org/log4j/2.x/javadoc/log4j-api/",
+        "https://www.javadocs.dev/org.apache.maven.resolver/maven-resolver-api/1.7.3",
+    )
+    options.tags("apiNote:a:API Note:")
+    options.tags("implNote:a:Implementation Note:")
+
+    inputs.files(javadocSourcepath).ignoreEmptyDirectories().withPropertyName(javadocSourcepath.name + "-configuration")
+    val javadocSourcepathElements = javadocSourcepath.elements
+    doFirst {
+        options.addStringOption(
+            "sourcepath",
+            javadocSourcepathElements.get().map { it.asFile }.joinToString(separator = File.pathSeparator, transform = File::getPath)
+        )
+    }
+
+    // workaround for https://github.com/gradle/gradle/issues/4046
+    inputs.dir("src/main/javadoc").withPropertyName("javadoc-sourceset")
+    val fsOps = services.fileSystemOperations
+    doLast {
+        fsOps.copy {
+            from("src/main/javadoc") {
+                include("**/doc-files/**")
+            }
+            into("build/docs/javadoc")
+        }
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+
+    // configure mockito agent that is needed in newer java versions
+    val provider = objects.newInstance<MockitoAgentProvider>()
+    provider.fileCollection.from(mockitoAgent)
+    jvmArgumentProviders.add(provider)
+}
+
+// Compile tests with -parameters for better junit parameterized test names
+tasks.compileTestJava {
+    options.compilerArgs.add("-parameters")
+}
+
+val scanJarForBadCalls by tasks.registering(io.papermc.paperweight.tasks.ScanJarForBadCalls::class) {
+    badAnnotations.add("Lio/papermc/paper/annotation/DoNotUse;")
+    jarToScan.set(tasks.jar.flatMap { it.archiveFile })
+    classpath.from(configurations.compileClasspath)
+}
+tasks.check {
+    dependsOn(scanJarForBadCalls)
+}
+// Gale start - hide irrelevant compilation warnings
+tasks.withType<JavaCompile> {
+    val compilerArgs = options.compilerArgs
+    compilerArgs.add("-Xlint:-module")
+    compilerArgs.add("-Xlint:-removal")
+    compilerArgs.add("-Xlint:-dep-ann")
+    compilerArgs.add("--add-modules=jdk.incubator.vector")
+}
+// Gale end - hide irrelevant compilation warnings
+tasks.jar {
+    from("${project.projectDir}/LICENSE.txt") {
+        into("")
+    }
+}

--- a/gale-api/build.gradle.kts.patch
+++ b/gale-api/build.gradle.kts.patch
@@ -1,0 +1,20 @@
+--- a/paper-api/build.gradle.kts
++++ b/paper-api/build.gradle.kts
+@@ -248,3 +_,20 @@
+ tasks.check {
+     dependsOn(scanJarForBadCalls)
+ }
++// Gale start - hide irrelevant compilation warnings
++tasks.withType<JavaCompile> {
++    val compilerArgs = options.compilerArgs
++    compilerArgs.add("-Xlint:-module")
++    compilerArgs.add("-Xlint:-removal")
++    compilerArgs.add("-Xlint:-dep-ann")
++    compilerArgs.add("--add-modules=jdk.incubator.vector")
++}
++// Gale end - hide irrelevant compilation warnings
++tasks.jar {
++    from("${project.projectDir}/LICENSE.txt") {
++        into("")
++    }
++}

--- a/gale-server/build.gradle.kts
+++ b/gale-server/build.gradle.kts
@@ -1,0 +1,357 @@
+import io.papermc.fill.model.BuildChannel
+import io.papermc.paperweight.attribute.DevBundleOutput
+import io.papermc.paperweight.util.*
+import java.time.Instant
+
+plugins {
+    `java-library`
+    `maven-publish`
+    idea
+    id("io.papermc.paperweight.core")
+    id("io.papermc.fill.gradle") version "1.0.11"
+}
+
+val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"
+
+dependencies {
+    mache("io.papermc:mache:26.2+build.1")
+    paperclip("io.papermc:paperclip:3.0.4")
+}
+
+paperweight {
+    minecraftVersion = providers.gradleProperty("mcVersion")
+    gitFilePatches = false
+
+    val gale = forks.register("gale") {
+        upstream.patchDir("paperServer") {
+            upstreamPath = "paper-server"
+            excludes = setOf("src/minecraft", "patches", "build.gradle.kts")
+            patchesDir = rootDirectory.dir("gale-server/paper-patches")
+            outputDir = rootDirectory.dir("paper-server")
+        }
+    }
+    activeFork = gale
+
+    updatingMinecraft {
+        // oldPaperCommit = "d4fe85375af18bfa88f44d7c1e6a61904ae550cc"
+    }
+}
+
+tasks.generateDevelopmentBundle {
+    libraryRepositories.addAll(
+        "https://repo.maven.apache.org/maven2/",
+        paperMavenPublicUrl,
+    )
+}
+
+abstract class Services {
+    @get:Inject
+    abstract val archiveOperations: ArchiveOperations
+}
+val services = objects.newInstance<Services>()
+
+if (project.providers.gradleProperty("publishDevBundle").isPresent) {
+    val devBundleComponent = publishing.softwareComponentFactory.adhoc("devBundle")
+    components.add(devBundleComponent)
+
+    val devBundle = configurations.consumable("devBundle") {
+        attributes.attribute(DevBundleOutput.ATTRIBUTE, objects.named(DevBundleOutput.ZIP))
+        outgoing.artifact(tasks.generateDevelopmentBundle.flatMap { it.devBundleFile })
+    }
+    devBundleComponent.addVariantsFromConfiguration(devBundle) {}
+
+    val runtime = configurations.consumable("serverRuntimeClasspath") {
+        attributes.attribute(DevBundleOutput.ATTRIBUTE, objects.named(DevBundleOutput.SERVER_DEPENDENCIES))
+        attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+        extendsFrom(configurations.runtimeClasspath.get())
+    }
+    devBundleComponent.addVariantsFromConfiguration(runtime) {
+        mapToMavenScope("runtime")
+    }
+
+    val compile = configurations.consumable("serverCompileClasspath") {
+        attributes.attribute(DevBundleOutput.ATTRIBUTE, objects.named(DevBundleOutput.SERVER_DEPENDENCIES))
+        attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_API))
+        extendsFrom(configurations.compileClasspath.get())
+    }
+    devBundleComponent.addVariantsFromConfiguration(compile) {
+        mapToMavenScope("compile")
+    }
+
+    tasks.withType(GenerateMavenPom::class).configureEach {
+        doLast {
+            val text = destination.readText()
+            // Remove dependencies from pom, dev bundle is designed for gradle module metadata consumers
+            destination.writeText(
+                text.substringBefore("<dependencies>") + text.substringAfter("</dependencies>")
+            )
+        }
+    }
+
+    publishing {
+        publications.create<MavenPublication>("devBundle") {
+            artifactId = "dev-bundle"
+            from(devBundleComponent)
+        }
+    }
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir("../paper-server/src/main/java")
+            srcDir("../paper-server/src/generated/java")
+        }
+        resources { srcDir("../paper-server/src/main/resources") }
+    }
+    test {
+        java { srcDir("../paper-server/src/test/java") }
+        resources { srcDir("../paper-server/src/test/resources") }
+    }
+}
+
+val log4jPlugins = sourceSets.create("log4jPlugins")
+configurations.named(log4jPlugins.compileClasspathConfigurationName) {
+    extendsFrom(configurations.compileClasspath.get())
+}
+val alsoShade: Configuration by configurations.creating
+
+val runtimeConfiguration by configurations.consumable("runtimeConfiguration") {
+    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+    extendsFrom(configurations.getByName(sourceSets.main.get().runtimeElementsConfigurationName))
+}
+
+// Configure mockito agent that is needed in newer java versions
+val mockitoAgent = configurations.register("mockitoAgent")
+abstract class MockitoAgentProvider : CommandLineArgumentProvider {
+    @get:CompileClasspath
+    abstract val fileCollection: ConfigurableFileCollection
+
+    override fun asArguments(): Iterable<String> {
+        return listOf("-javaagent:" + fileCollection.files.single().absolutePath)
+    }
+}
+
+dependencies {
+    implementation(project(":gale-api"))
+    implementation("ca.spottedleaf:concurrentutil:0.0.10")
+    implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
+    implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
+    implementation("net.minecrell:terminalconsoleappender:1.3.0")
+    implementation("net.kyori:adventure-text-serializer-ansi")
+
+    /*
+      Required to add the missing Log4j2Plugins.dat file from log4j-core
+      which has been removed by Mojang. Without it, log4j has to classload
+      all its classes to check if they are plugins.
+      Scanning takes about 1-2 seconds so adding this speeds up the server start.
+     */
+    implementation("org.apache.logging.log4j:log4j-core:2.26.0")
+    log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:2.26.0") // Needed to generate meta for our Log4j plugins
+    runtimeOnly(log4jPlugins.output)
+    alsoShade(log4jPlugins.output)
+
+    implementation("com.velocitypowered:velocity-native:3.4.0-SNAPSHOT") {
+        isTransitive = false
+    }
+    implementation("io.netty:netty-codec-haproxy:4.2.15.Final") // Add support for proxy protocol
+    implementation("org.apache.logging.log4j:log4j-iostreams:2.26.0")
+    implementation("org.ow2.asm:asm-commons:9.9.1")
+    implementation("org.spongepowered:configurate-yaml:4.2.0")
+
+    // Deps that were previously in the API but have now been moved here for backwards compat, eventually to be removed
+    runtimeOnly("commons-lang:commons-lang:2.6")
+    runtimeOnly("org.xerial:sqlite-jdbc:3.49.1.0")
+    runtimeOnly("com.mysql:mysql-connector-j:9.2.0")
+    runtimeOnly("com.lmax:disruptor:3.4.4")
+    implementation("com.googlecode.json-simple:json-simple:1.1.1") { // change to runtimeOnly once Timings is removed
+        isTransitive = false // includes junit
+    }
+
+    testImplementation("io.github.classgraph:classgraph:4.8.184") // For mob goal test
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.3")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
+    testImplementation("org.junit.platform:junit-platform-suite-engine:6.0.3")
+    testImplementation("org.hamcrest:hamcrest:2.2")
+    testImplementation("org.mockito:mockito-core:5.22.0")
+    mockitoAgent("org.mockito:mockito-core:5.22.0") { isTransitive = false } // Configure mockito agent that is needed in newer java versions
+    testImplementation("org.ow2.asm:asm-tree:9.9.1")
+    testImplementation("org.junit-pioneer:junit-pioneer:2.3.0") // CartesianTest
+
+    // Spark
+    implementation("me.lucko:spark-api:0.1-20240720.200737-2")
+    implementation("me.lucko:spark-paper:1.10.152")
+}
+
+tasks.jar {
+    manifest {
+        val git = Git(rootProject.layout.projectDirectory.path)
+        val mcVersion = rootProject.providers.gradleProperty("mcVersion").get()
+        val build = System.getenv("BUILD_NUMBER") ?: null
+        val buildTime = providers.environmentVariable("BUILD_STARTED_AT").map(Instant::parse).orElse(Instant.EPOCH).get()
+        val gitHash = git.exec(providers, "rev-parse", "--short=7", "HEAD").get().trim()
+        val implementationVersion = "$mcVersion-${build ?: "DEV"}-$gitHash"
+        val date = git.exec(providers, "show", "-s", "--format=%ci", gitHash).get().trim()
+        val gitBranch = git.exec(providers, "rev-parse", "--abbrev-ref", "HEAD").get().trim()
+        attributes(
+            "Main-Class" to "org.bukkit.craftbukkit.Main",
+    "Implementation-Title" to "Gale",
+    "Implementation-Version" to implementationVersion,
+    "Implementation-Vendor" to date,
+    "Specification-Title" to "Gale",
+    "Specification-Version" to project.version,
+    "Specification-Vendor" to "GaleMC",
+    "Brand-Id" to "org.galemc:gale",
+    "Brand-Name" to "Gale",
+            "Build-Number" to (build ?: ""),
+            "Build-Time" to buildTime.toString(),
+            "Git-Branch" to gitBranch,
+            "Git-Commit" to gitHash,
+        )
+        for (tld in setOf("net", "com", "org")) {
+            attributes("$tld/bukkit", "Sealed" to true)
+        }
+    }
+}
+
+// Compile tests with -parameters for better junit parameterized test names
+tasks.compileTestJava {
+    options.compilerArgs.add("-parameters")
+}
+
+// Bump compile tasks to 1GB memory to avoid OOMs
+tasks.withType<JavaCompile>().configureEach {
+    options.forkOptions.memoryMaximumSize = "1G"
+}
+
+val scanJarForBadCalls by tasks.registering(io.papermc.paperweight.tasks.ScanJarForBadCalls::class) {
+    badAnnotations.add("Lio/papermc/paper/annotation/DoNotUse;")
+    jarToScan.set(tasks.jar.flatMap { it.archiveFile })
+    classpath.from(configurations.compileClasspath)
+}
+tasks.check {
+    dependsOn(scanJarForBadCalls)
+}
+
+// Use TCA for console improvements
+tasks.jar {
+    val archiveOperations = services.archiveOperations
+    from(alsoShade.elements.map {
+        it.map { f ->
+            if (f.asFile.isFile) {
+                archiveOperations.zipTree(f.asFile)
+            } else {
+                f.asFile
+            }
+        }
+    })
+}
+
+tasks.test {
+    include("**/**TestSuite.class")
+    workingDir = temporaryDir
+    useJUnitPlatform {
+        forkEvery = 1
+        excludeTags("Slow")
+    }
+
+    // Configure mockito agent that is needed in newer java versions
+    val provider = objects.newInstance<MockitoAgentProvider>()
+    provider.fileCollection.from(mockitoAgent)
+    jvmArgumentProviders.add(provider)
+}
+
+val generatedDir: java.nio.file.Path = layout.projectDirectory.dir("src/generated/java").asFile.toPath()
+idea {
+    module {
+        generatedSourceDirs.add(generatedDir.toFile())
+    }
+}
+sourceSets {
+    main {
+        java {
+            srcDir(generatedDir)
+        }
+    }
+}
+
+fun TaskContainer.registerRunTask(
+    name: String,
+    block: JavaExec.() -> Unit
+): TaskProvider<JavaExec> = register<JavaExec>(name) {
+    group = "runs"
+    mainClass.set("org.bukkit.craftbukkit.Main")
+    standardInput = System.`in`
+    workingDir = rootProject.layout.projectDirectory
+        .dir(providers.gradleProperty("paper.runWorkDir").getOrElse("run"))
+        .asFile
+    javaLauncher.set(project.javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(25))
+        // TODO - JB runtime 25 has issues with spark rn
+        // vendor.set(JvmVendorSpec.JETBRAINS)
+    })
+    //jvmArgs("-XX:+AllowEnhancedClassRedefinition")
+
+    if (rootProject.childProjects["test-plugin"] != null) {
+        val testPluginJar = rootProject.project(":test-plugin").tasks.jar.flatMap { it.archiveFile }
+        inputs.file(testPluginJar)
+        args("-add-plugin=${testPluginJar.get().asFile.absolutePath}")
+    }
+
+    args("--nogui")
+    systemProperty("net.kyori.adventure.text.warnWhenLegacyFormattingDetected", true)
+    if (providers.gradleProperty("paper.runDisableWatchdog").getOrElse("false") == "true") {
+        systemProperty("disable.watchdog", true)
+    }
+    systemProperty("io.papermc.paper.suppress.sout.nags", true)
+    systemProperty("paper.maxChatCommandInputSize", 32767)
+
+    val memoryGb = providers.gradleProperty("paper.runMemoryGb").getOrElse("2")
+    minHeapSize = "${memoryGb}G"
+    maxHeapSize = "${memoryGb}G"
+
+    doFirst {
+        workingDir.mkdirs()
+    }
+
+    block(this)
+}
+
+tasks.registerRunTask("runServer") {
+    description = "Spin up a test server from the Mojang mapped server jar"
+    classpath(tasks.jar)
+    classpath(configurations.runtimeClasspath)
+}
+
+tasks.registerRunTask("runDevServer") {
+    description = "Spin up a test server without assembling a jar"
+    classpath(sourceSets.main.map { it.runtimeClasspath })
+}
+
+tasks.registerRunTask("runBundler") {
+    description = "Spin up a test server from the Mojang mapped bundler jar"
+    classpath(tasks.createBundlerJar.flatMap { it.outputZip })
+    mainClass.set(null as String?)
+}
+tasks.registerRunTask("runPaperclip") {
+    description = "Spin up a test server from the Mojang mapped Paperclip jar"
+    classpath(tasks.createPaperclipJar.flatMap { it.outputZip })
+    mainClass.set(null as String?)
+}
+
+fill {
+    project("paper")
+    versionFamily(paperweight.minecraftVersion.map { it.split(".", "-").takeWhile { part -> part.toIntOrNull() != null }.take(2).joinToString(".") })
+    version(paperweight.minecraftVersion)
+
+    build {
+        channel = providers.gradleProperty("channel").map { BuildChannel.valueOf(it.uppercase()) }
+
+        downloads {
+            register("server:default") {
+                file = tasks.createPaperclipJar.flatMap { it.outputZip }
+                nameResolver.set { project, _, version, build -> "$project-$version-$build.jar" }
+            }
+        }
+    }
+}

--- a/gale-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -1,0 +1,34 @@
+--- a/net/minecraft/server/level/ServerLevel.java
++++ b/net/minecraft/server/level/ServerLevel.java
+@@ -1716,6 +1716,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+ 
+     @Override
+     public void destroyBlockProgress(final int id, final BlockPos blockPos, final int progress) {
++        // Gale start - reduce block destruction packet allocations
++        var players = this.server.getPlayerList().getPlayers();
++        if (players.isEmpty()) {
++            return;
++        }
++        ClientboundBlockDestructionPacket packet = new ClientboundBlockDestructionPacket(id, blockPos, progress);
++        // Gale end
+         // CraftBukkit start
+         Player breakerPlayer = null;
+         Entity entity = this.getEntity(id);
+@@ -1732,7 +1739,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+                 .callEvent();
+         }
+         // Paper end - Add BlockBreakProgressUpdateEvent
+-        for (ServerPlayer player : this.server.getPlayerList().getPlayers()) {
++        for (ServerPlayer player : players) { // Gale - reduce block destruction packet allocations
+             if (player.level() == this && player.getId() != id) {
+                 double xd = blockPos.getX() - player.getX();
+                 double yd = blockPos.getY() - player.getY();
+@@ -1743,7 +1750,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+                         continue;
+                     }
+                     // CraftBukkit end
+-                    player.connection.send(new ClientboundBlockDestructionPacket(id, blockPos, progress));
++                    player.connection.send(packet); // Gale - reduce block destruction packet allocations
+                 }
+             }
+         }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1,0 +1,43 @@
+--- a/net/minecraft/world/entity/Entity.java
++++ b/net/minecraft/world/entity/Entity.java
+@@ -280,6 +280,7 @@ public abstract class Entity
+     public float yRotO;
+     public float xRotO;
+     private AABB bb = INITIAL_AABB;
++    private boolean boundingBoxChanged = false; // Gale - skip entity move if movement is zero
+     public boolean onGround;
+     public boolean horizontalCollision;
+     public boolean verticalCollision;
+@@ -1182,7 +1183,19 @@ public abstract class Entity
+                 return;
+             }
+             // Paper end
+-
++            // Gale start - skip entity move if movement is zero
++            if (!this.boundingBoxChanged && delta.equals(Vec3.ZERO)) {
++                this.horizontalCollision = false;
++                this.verticalCollision = false;
++                this.verticalCollisionBelow = false;
++                this.minorHorizontalCollision = false;
++                this.setOnGroundWithMovement(false, false, Vec3.ZERO);
++                boundingBoxChanged = false;
++                profiler.pop();
++                return;
++            }
++            boundingBoxChanged = false;
++            // Gale end - skip entity move if movement is zero
+             delta = this.maybeBackOffFromEdge(delta, moverType);
+             Vec3 movement = this.collide(delta);
+             double movementLength = movement.lengthSqr();
+@@ -4580,6 +4593,11 @@ public abstract class Entity
+     }
+ 
+     public final void setBoundingBox(final AABB bb) {
++        // Gale start - skip entity move if movement is zero
++        if (!this.bb.equals(bb)) {
++            this.boundingBoxChanged = true;
++        }
++        // Gale end - skip entity move if movement is zero
+         // CraftBukkit start - block invalid bounding boxes
+         double minX = bb.minX,
+                 minY = bb.minY,

--- a/gale-server/paper-patches/features/0001-Gale-branding.patch
+++ b/gale-server/paper-patches/features/0001-Gale-branding.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: RuleGaed <arasomeroguz9@gmail.com>
+Date: Thu, 18 Jun 2026 20:02:13 +0300
+Subject: [PATCH] Gale branding changes
+
+License: GPL-3.0 (https://www.gnu.org/licenses/gpl-3.0.html)
+Gale - https://galemc.org
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
+index ba32d58c3..0dcc19205 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
++++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
+@@ -40,10 +40,10 @@ public class PaperVersionFetcher implements VersionFetcher {
+     private static final ComponentLogger COMPONENT_LOGGER = ComponentLogger.logger(LogManager.getRootLogger().getName());
+     private static final int DISTANCE_ERROR = -1;
+     private static final int DISTANCE_UNKNOWN = -2;
+-    private static final String DOWNLOAD_PAGE = "https://papermc.io/downloads/paper";
+-    private static final String REPOSITORY = "PaperMC/Paper";
++    private static final String DOWNLOAD_PAGE = "https://github.com/GaleMC/Gale";
++    private static final String REPOSITORY = "GaleMC/Gale";
+     private static final ServerBuildInfo BUILD_INFO = ServerBuildInfo.buildInfo();
+-    private static final String USER_AGENT = BUILD_INFO.brandName() + "/" + BUILD_INFO.asString(VERSION_SIMPLE) + " (https://papermc.io)";
++    private static final String USER_AGENT = BUILD_INFO.brandName() + "/" + BUILD_INFO.asString(VERSION_SIMPLE) + " (https://galemc.org)";
+     private static final Gson GSON = new Gson();
+ 
+     @Override
+diff --git a/src/main/java/com/destroystokyo/paper/console/PaperConsole.java b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
+index 6ee39b534..136f752da 100644
+--- a/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
++++ b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
+@@ -20,7 +20,7 @@ public final class PaperConsole extends SimpleTerminalConsole {
+     @Override
+     protected LineReader buildReader(LineReaderBuilder builder) {
+         builder
+-                .appName("Paper")
++                .appName("Gale")
+                 .variable(LineReader.HISTORY_FILE, java.nio.file.Paths.get(".console_history"))
+                 .completer(new ConsoleCommandCompleter(this.server))
+                 .option(LineReader.Option.COMPLETE_IN_WORD, true);
+diff --git a/src/main/java/org/spigotmc/WatchdogThread.java b/src/main/java/org/spigotmc/WatchdogThread.java
+index aec0bd17d..2ab00992c 100644
+--- a/src/main/java/org/spigotmc/WatchdogThread.java
++++ b/src/main/java/org/spigotmc/WatchdogThread.java
+@@ -75,12 +75,12 @@ public class WatchdogThread extends ca.spottedleaf.moonrise.common.util.TickThre
+                 this.lastEarlyWarning = currentTime;
+                 if (isLongTimeout) {
+                     logger.log(Level.SEVERE, "------------------------------");
+-                    logger.log(Level.SEVERE, "The server has stopped responding! This is (probably) not a Paper bug."); // Paper
++                    logger.log(Level.SEVERE, "The server has stopped responding! This is (probably) not a Paper bug.");
+                     logger.log(Level.SEVERE, "If you see a plugin in the Server thread dump below, then please report it to that author");
+                     logger.log(Level.SEVERE, "\t *Especially* if it looks like HTTP or MySQL operations are occurring");
+                     logger.log(Level.SEVERE, "If you see a world save or edit, then it means you did far more than your server can handle at once");
+                     logger.log(Level.SEVERE, "\t If this is the case, consider increasing timeout-time in spigot.yml but note that this will replace the crash with LARGE lag spikes");
+-                    logger.log(Level.SEVERE, "If you are unsure or still think this is a Paper bug, please report this to https://github.com/PaperMC/Paper/issues");
++                    logger.log(Level.SEVERE, "If you are unsure or still think this is a Paper bug, please report this to https://github.com/PaperMC/Paper/issues - If you think this is a Gale bug, report at https://github.com/GaleMC/Gale/issues");
+                     logger.log(Level.SEVERE, "Be sure to include ALL relevant console errors and Minecraft crash reports");
+                     logger.log(Level.SEVERE, "Paper version: " + Bukkit.getServer().getVersion());
+ 
+@@ -102,12 +102,12 @@ public class WatchdogThread extends ca.spottedleaf.moonrise.common.util.TickThre
+                     }
+                     // Paper end
+                 } else {
+-                    logger.log(Level.SEVERE, "--- DO NOT REPORT THIS TO PAPER - THIS IS NOT A BUG OR A CRASH  - " + Bukkit.getServer().getVersion() + " ---");
++                    logger.log(Level.SEVERE, "--- DO NOT REPORT THIS TO PAPER - If you think this is a Gale bug, report at https://github.com/GaleMC/Gale/issues - " + Bukkit.getServer().getVersion() + " ---");
+                     logger.log(Level.SEVERE, "The server has not responded for " + (currentTime - lastTick) / 1000 + " seconds! Creating thread dump");
+                 }
+                 // Paper end - Different message for short timeout
+                 logger.log(Level.SEVERE, "------------------------------");
+-                logger.log(Level.SEVERE, "Server thread dump (Look for plugins here before reporting to Paper!):"); // Paper
++                logger.log(Level.SEVERE, "Server thread dump (Look for plugins here before reporting to Gale!):");
+                 FeatureHooks.dumpAllChunkLoadInfo(MinecraftServer.getServer(), isLongTimeout); // Paper - log detailed tick information
+                 WatchdogThread.dumpThread(ManagementFactory.getThreadMXBean().getThreadInfo(MinecraftServer.getServer().getRunningThread().threadId(), Integer.MAX_VALUE), logger);
+                 logger.log(Level.SEVERE, "------------------------------");
+@@ -120,7 +120,7 @@ public class WatchdogThread extends ca.spottedleaf.moonrise.common.util.TickThre
+                         WatchdogThread.dumpThread(thread, logger);
+                     }
+                 } else {
+-                    logger.log(Level.SEVERE, "--- DO NOT REPORT THIS TO PAPER - THIS IS NOT A BUG OR A CRASH ---");
++                    logger.log(Level.SEVERE, "--- DO NOT REPORT THIS TO PAPER - If you think this is a Gale bug, report at https://github.com/GaleMC/Gale/issues ---");
+                 }
+ 
+                 logger.log(Level.SEVERE, "------------------------------");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,13 @@
 group=org.galemc.gale
-version=1.20.2-R0.1-SNAPSHOT
+mcVersion=26.2
+apiVersion=26.2
+channel=ALPHA
 
-mcVersion=1.20.2
-paperRef=e284bb12156fad92767ceadf3d5e57cbc71e5b21
+paperCommit=11427785e07eb16fbc7d6ff4eefd3c8ac28a0509
 
+org.gradle.configuration-cache=true
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.vfs.watch=false
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=1G -XX:+UseG1GC
+org.gradle.java.home=C:/Program Files/Java/jdk-25.0.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,19 +1,15 @@
-import java.util.Locale
-
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven("https://repo.galemc.org/repository/maven-public/")
         maven("https://repo.papermc.io/repository/maven-public/")
     }
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
 
 if (!file(".git").exists()) {
-    // Gale start - build changes
     val errorText = """
         
         =====================[ ERROR ]=====================
@@ -26,18 +22,17 @@ if (!file(".git").exists()) {
          Built Gale jars are available for download at
          https://github.com/GaleMC/Gale/actions
          
-         See https://github.com/PaperMC/Paper/blob/master/CONTRIBUTING.md
+         See https://github.com/PaperMC/Paper/blob/main/CONTRIBUTING.md
          for further information on building and modifying Paper forks.
         ===================================================
     """.trimIndent()
-    // Gale end - build changes
     error(errorText)
 }
 
-rootProject.name = "gale" // Gale - build changes
+rootProject.name = "gale"
 
-for (name in listOf("gale-api", "gale-server")) { // Gale - build changes
-    val projName = name.lowercase(Locale.ENGLISH)
+for (name in listOf("gale-api", "gale-server")) {
+    val projName = name.lowercase()
     include(projName)
     findProject(":$projName")!!.projectDir = file(name)
 }


### PR DESCRIPTION
- Update build system to Paper 26.2, Java 25, Gradle 9.4.1
- Port branding (console, watchdog, version fetcher)
- Port optimizations: skip entity move, reduce block destruction packets
- Clean up old 1.20.2 patches
- Update README