### PR TITLE
Cache Identifier toString and hash

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/resources/Identifier.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/resources/Identifier.java.patch
@@ -1,18 +1,18 @@
 --- a/net/minecraft/resources/Identifier.java
 +++ b/net/minecraft/resources/Identifier.java
-@@ -25,6 +25,10 @@
-     public static final String ALLOWED_NAMESPACE_CHARACTERS = "[a-z0-9_.-]";
+@@ -26,6 +26,10 @@
+     public static final String PAPER_NAMESPACE = "paper"; // Paper
      private final String namespace;
      private final String path;
 +    // Gale start - Cache identifier toString and hash
 +    private String identifierStr;
 +    private int hash;
 +    // Gale end - Cache identifier toString and hash
-
+ 
      private Identifier(final String namespace, final String path) {
          assert isValidNamespace(namespace);
-@@ -123,7 +127,14 @@
-
+@@ -131,7 +135,14 @@
+ 
      @Override
      public String toString() {
 -        return this.namespace + ":" + this.path;
@@ -25,10 +25,10 @@
 +        return identifierStr;
 +        // Gale end - Cache identifier toString and hash
      }
-
+ 
      @Override
-@@ -133,7 +144,14 @@
-
+@@ -141,7 +152,14 @@
+ 
      @Override
      public int hashCode() {
 -        return 31 * this.namespace.hashCode() + this.path.hashCode();
@@ -41,5 +41,5 @@
 +        return hash;
 +        // Gale end - Cache identifier toString and hash
      }
-
+ 
      @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/resources/Identifier.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/resources/Identifier.java.patch
@@ -1,0 +1,45 @@
+--- a/net/minecraft/resources/Identifier.java
++++ b/net/minecraft/resources/Identifier.java
+@@ -25,6 +25,10 @@
+     public static final String ALLOWED_NAMESPACE_CHARACTERS = "[a-z0-9_.-]";
+     private final String namespace;
+     private final String path;
++    // Gale start - Cache identifier toString and hash
++    private String identifierStr;
++    private int hash;
++    // Gale end - Cache identifier toString and hash
+
+     private Identifier(final String namespace, final String path) {
+         assert isValidNamespace(namespace);
+@@ -123,7 +127,14 @@
+
+     @Override
+     public String toString() {
+-        return this.namespace + ":" + this.path;
++        // Gale start - Cache identifier toString and hash
++        String identifierStr = this.identifierStr;
++        if (identifierStr == null) {
++            identifierStr = this.namespace + ":" + this.path;
++            this.identifierStr = identifierStr;
++        }
++        return identifierStr;
++        // Gale end - Cache identifier toString and hash
+     }
+
+     @Override
+@@ -133,7 +144,14 @@
+
+     @Override
+     public int hashCode() {
+-        return 31 * this.namespace.hashCode() + this.path.hashCode();
++        // Gale start - Cache identifier toString and hash
++        int hash = this.hash;
++        if (hash == 0) {
++            hash = 31 * this.namespace.hashCode() + this.path.hashCode();
++            this.hash = hash;
++        }
++        return hash;
++        // Gale end - Cache identifier toString and hash
+     }
+
+     @Override


### PR DESCRIPTION
Port Leaf patch 0297 Cache identifier toString and hash by OverwriteMC
Lazily cache toString result and hashCode to reduce allocations for the most frequently used resource location type