### PR TITLE
Release packed seenBy bit on disconnect

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -16,6 +16,7 @@
              }
          }
 +        craftPlayer.resetCanSee(); // Gale - Intrusive values - CraftPlayer.invertedVisibilityEntities
++        net.minecraft.server.network.ServerGamePacketListenerImpl.USED_PACKED_SEEN_BY_BIT_INDICES[player.connection.packedSeenByBitIndex] = false; // Gale - Collections - ChunkMap.TrackedEntity.seenBy
          // This removes the scoreboard (and player reference) for the specific player in the manager
          this.cserver.getScoreboardManager().removePlayer(player.getBukkitEntity());
          // CraftBukkit end


### PR DESCRIPTION
**Motivation**
The packed tracking bit is allocated per `ServerGamePacketListenerImpl`, but it was not released on player disconnect. On servers running for days or weeks with join/quit churn, new connections could keep receiving higher bit indices, causing tracked entity packed arrays to grow more than necessary ^^ 

**Changes**
Clear player's packed tracking bit on disconnection

**Checklist**
- [x] Patches apply cleanly (`./gradlew applyAllPatches`)
- [x] Paperclip jar builds (`./gradlew :gale-server:createPaperclipJar`)
- [x] Tests pass (if applicable)
