### PR TITLE
Restore enchantment value equality

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/item/enchantment/Enchantment.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/item/enchantment/Enchantment.java.patch
@@ -42,6 +42,20 @@
 +    public HolderSet<Enchantment> exclusiveSet() { return this.exclusiveSet; }
 +    public DataComponentMap effects() { return this.effects; }
 +
++    @Override
++    public boolean equals(Object obj) {
++        return this == obj || obj instanceof Enchantment other && java.util.Objects.equals(this.description, other.description) && java.util.Objects.equals(this.definition, other.definition) && java.util.Objects.equals(this.exclusiveSet, other.exclusiveSet) && java.util.Objects.equals(this.effects, other.effects);
++    }
++
++    @Override
++    public int hashCode() {
++        int result = this.description.hashCode();
++        result = 31 * result + this.definition.hashCode();
++        result = 31 * result + this.exclusiveSet.hashCode();
++        result = 31 * result + this.effects.hashCode();
++        return result;
++    }
++
 +    /**
 +     * Contains a boolean for each {@link EquipmentSlot}.
 +     */


### PR DESCRIPTION
**Motivation**
Fix a behavior difference from Paper caused by changing `Enchantment` from a record to a normal class.

Gale changed Enchantment from record to normal class for optimization. But record had auto equals() and hashCode()` After that change, two enchantments with same data were not equal anymore on Gale, while Paper returns equal. This behavioir change can affect plugins that compares enchantment values directly or uses them in hash-based collections ^^ 



**Changes**
- Make two `Enchantment` objects equal when their real enchantment data is equal.
- Keep Gale’s precomputed slot data out of the comparison, because it is only cached data from the same enchantment definition.


Tested with two custom enchantments with identical data but different IDs, here's the [datapack ](https://cdn.discordapp.com/attachments/1050121125021094029/1521612146067116053/enchantment-equality-compare.7z?ex=6a45773d&is=6a4425bd&hm=b45d694a62fd69b0d173c477034fc7ceea5f150b9260918a8bd869b6055424f3&) I used to test it.


**Checklist**
- [x] Patches apply cleanly (`./gradlew applyAllPatches`)
- [x] Paperclip jar builds (`./gradlew :gale-server:createPaperclipJar`)
- [x] Tests pass (if applicable)
