### PR TITLE
Fix Identifier parsing string cache

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/resources/Identifier.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/resources/Identifier.java.patch
@@ -11,19 +11,6 @@
  
      private Identifier(final String namespace, final String path) {
          assert isValidNamespace(namespace);
-@@ -50,7 +_,11 @@
-     }
- 
-     public static Identifier parse(final String identifier) {
--        return bySeparator(identifier, ':');
-+        // Gale start - Cache - Identifier.hashCode() and Identifier.toString()
-+        Identifier toReturn = bySeparator(identifier, ':');
-+        toReturn.cachedString = identifier;
-+        return toReturn;
-+        // Gale end - Cache - Identifier.hashCode() and Identifier.toString()
-     }
- 
-     public static Identifier withDefaultNamespace(final String path) {
 @@ -131,7 +_,14 @@
  
      @Override


### PR DESCRIPTION
**Changes**
Fixes `Identifier.parse("stone").toString()` returning "stone" on Gale instead of `minecraft:stone` (Paper), which may break plugins depend to full names 

**Checklist**
- [x] Patches apply cleanly (`./gradlew applyAllPatches`)
- [x] Paperclip jar builds (`./gradlew :gale-server:createPaperclipJar`)
- [x] Tests pass (if applicable)
