### PR TITLE
Fix isAlive cache initialization during player construction

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -31,7 +31,7 @@
          this.setYRot(this.random.nextFloat() * (float) (Math.PI * 2));
          this.yHeadRot = this.getYRot();
          this.brain = this.makeBrain(Brain.Packed.EMPTY);
-+        this.gale$eventDriven_isAlive_update(); // Gale - Event-driven - LivingEntity.isAlive
++        this.gale$eventDriven_isAlive_updateFor_health(this.entityData.get(DATA_HEALTH_ID)); // Gale - Event-driven - LivingEntity.isAlive
      }
  
      @Override


### PR DESCRIPTION
**Changes**
Latest isAlive cache change initialized cache inside LivingEntity constructor by calling the normal update method.

That normal update method calls getHealth() for players, and getHealth() goes through Bukkit's CraftPlayer, but at this point ServerPlayer is still being created, so the Bukkit player object still isn't ready yet. So because of this problem, player join can fail during construction.

This patch initializes the isAlive cache from the health value already stored in entity data instead ^^

**Checklist**
- [x] Patches apply cleanly (`./gradlew applyAllPatches`)
- [x] Paperclip jar builds (`./gradlew :gale-server:createPaperclipJar`)
- [x] Tests pass (if applicable)
