### PR TITLE
fix player passenger count cache

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -130,6 +130,17 @@
      }
  
 +    public void setVehicle(@Nullable Entity vehicle) {
++        Entity oldVehicle = this.vehicle;
++        if (oldVehicle == vehicle) return;
++        int playerPassengerCount = this.gale$eventDriven_playerPassengerCount;
++        if (playerPassengerCount != 0) {
++            if (oldVehicle != null) {
++                oldVehicle.gale$eventDriven_playerPassengerCount_add(-playerPassengerCount);
++            }
++            if (vehicle != null) {
++                vehicle.gale$eventDriven_playerPassengerCount_add(playerPassengerCount);
++            }
++        }
 +        this.vehicle = vehicle;
 +    }
 +
@@ -178,16 +189,17 @@
 +    private int gale$eventDriven_playerPassengerCount;
 +
 +    public void gale$eventDriven_playerPassengerCount_increment() {
-+        this.gale$eventDriven_playerPassengerCount++;
-+        if (this.vehicle != null) {
-+            this.vehicle.gale$eventDriven_playerPassengerCount_increment();
-+        }
++        this.gale$eventDriven_playerPassengerCount_add(1);
 +    }
 +
 +    public void gale$eventDriven_playerPassengerCount_decrement() {
-+        this.gale$eventDriven_playerPassengerCount--;
++        this.gale$eventDriven_playerPassengerCount_add(-1);
++    }
++
++    private void gale$eventDriven_playerPassengerCount_add(int delta) {
++        this.gale$eventDriven_playerPassengerCount += delta;
 +        if (this.vehicle != null) {
-+            this.vehicle.gale$eventDriven_playerPassengerCount_decrement();
++            this.vehicle.gale$eventDriven_playerPassengerCount_add(delta);
 +        }
 +    }
 +


### PR DESCRIPTION
Gale is currently caching player passenger count, but the cache was only updated when the player itself mounted or dismounted something, this  was missing cases where an entity already carrying a player mounts another entity. 

As an example to this: 
`minecart -> pig -> player`
In this case, top vehicle could have cached 0 player passengers even though Paper sees 1

**Changes**
Moved the cached player passenger count when an entity changes vehicle.

If entity has no player passengers, this stays cheap and only updates the vehicle field. If it has a player passenger, the old vehicle chain gets the count removed and the new vehicle chain gets the count added ^^

**Checklist**
- [x] Patches apply cleanly (`./gradlew applyAllPatches`)
- [x] Paperclip jar builds (`./gradlew :gale-server:createPaperclipJar`)
- [x] Tests pass (if applicable)
