### PR TITLE
Event-driven can remove when far away

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -86,6 +86,24 @@
      }
  
      @Override
+@@ -1395,7 +_,7 @@
+             // Paper end - log detailed entity tick information
+         entity.setOldPosAndRot();
+         ProfilerFiller profiler = Profiler.get();
+-        entity.tickCount++;
++        entity.setTickCount(entity.tickCount + 1); // Gale - Event-driven - Cat.canRemoveWhenFarAway, Ocelot.canRemoveWhenFarAway
+         entity.totalEntityAge++; // Paper - age-like counter for all entities
+         profiler.push(entity.typeHolder()::getRegisteredName);
+         profiler.incrementCounter("tickNonPassenger");
+@@ -1423,7 +_,7 @@
+             entity.stopRiding();
+         } else if (entity instanceof Player || this.entityTickList.contains(entity)) {
+             entity.setOldPosAndRot();
+-            entity.tickCount++;
++            entity.setTickCount(entity.tickCount + 1); // Gale - Event-driven - Cat.canRemoveWhenFarAway, Ocelot.canRemoveWhenFarAway
+             entity.totalEntityAge++; // Paper - age-like counter for all entities
+             ProfilerFiller profiler = Profiler.get();
+             profiler.push(entity.typeHolder()::getRegisteredName);
 @@ -1716,6 +_,13 @@
  
      @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -86,24 +86,6 @@
      }
  
      @Override
-@@ -1396,6 +_,8 @@
-         entity.setOldPosAndRot();
-         ProfilerFiller profiler = Profiler.get();
-         entity.tickCount++;
-+        if (entity instanceof net.minecraft.world.entity.animal.feline.Cat cat) cat.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Cat.canRemoveWhenFarAway
-+        else if (entity instanceof net.minecraft.world.entity.animal.feline.Ocelot ocelot) ocelot.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Ocelot.canRemoveWhenFarAway
-         entity.totalEntityAge++; // Paper - age-like counter for all entities
-         profiler.push(entity.typeHolder()::getRegisteredName);
-         profiler.incrementCounter("tickNonPassenger");
-@@ -1424,6 +_,8 @@
-         } else if (entity instanceof Player || this.entityTickList.contains(entity)) {
-             entity.setOldPosAndRot();
-             entity.tickCount++;
-+            if (entity instanceof net.minecraft.world.entity.animal.feline.Cat cat) cat.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Cat.canRemoveWhenFarAway
-+            else if (entity instanceof net.minecraft.world.entity.animal.feline.Ocelot ocelot) ocelot.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Ocelot.canRemoveWhenFarAway
-             entity.totalEntityAge++; // Paper - age-like counter for all entities
-             ProfilerFiller profiler = Profiler.get();
-             profiler.push(entity.typeHolder()::getRegisteredName);
 @@ -1716,6 +_,13 @@
  
      @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -86,6 +86,24 @@
      }
  
      @Override
+@@ -1396,6 +_,8 @@
+         entity.setOldPosAndRot();
+         ProfilerFiller profiler = Profiler.get();
+         entity.tickCount++;
++        if (entity instanceof net.minecraft.world.entity.animal.feline.Cat cat) cat.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Cat.canRemoveWhenFarAway
++        else if (entity instanceof net.minecraft.world.entity.animal.feline.Ocelot ocelot) ocelot.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Ocelot.canRemoveWhenFarAway
+         entity.totalEntityAge++; // Paper - age-like counter for all entities
+         profiler.push(entity.typeHolder()::getRegisteredName);
+         profiler.incrementCounter("tickNonPassenger");
+@@ -1424,6 +_,8 @@
+         } else if (entity instanceof Player || this.entityTickList.contains(entity)) {
+             entity.setOldPosAndRot();
+             entity.tickCount++;
++            if (entity instanceof net.minecraft.world.entity.animal.feline.Cat cat) cat.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Cat.canRemoveWhenFarAway
++            else if (entity instanceof net.minecraft.world.entity.animal.feline.Ocelot ocelot) ocelot.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Ocelot.canRemoveWhenFarAway
+             entity.totalEntityAge++; // Paper - age-like counter for all entities
+             ProfilerFiller profiler = Profiler.get();
+             profiler.push(entity.typeHolder()::getRegisteredName);
 @@ -1716,6 +_,13 @@
  
      @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -26,12 +26,17 @@
      public static final float DEFAULT_BB_WIDTH = 0.6F;
      public static final float DEFAULT_BB_HEIGHT = 1.8F;
      public float moveDist;
-@@ -299,14 +_,14 @@
+@@ -299,14 +_,19 @@
      public double zOld;
      public boolean noPhysics;
      protected final RandomSource random = SHARED_RANDOM; // Paper - Share random for entities to make them more random
 -    public int tickCount;
-+    public int tickCount; // Gale - Event-driven - Cat.canRemoveWhenFarAway, Ocelot.canRemoveWhenFarAway - TODO Watch for new writes
++    // Gale start - Event-driven - Cat.canRemoveWhenFarAway, Ocelot.canRemoveWhenFarAway
++    public int tickCount; // TODO Watch for new writes
++    public void setTickCount(int newTickCount) {
++        this.tickCount = newTickCount;
++    }
++    // Gale end - Event-driven - Cat.canRemoveWhenFarAway, Ocelot.canRemoveWhenFarAway
      private int remainingFireTicks;
      private final EntityFluidInteraction fluidInteraction = new EntityFluidInteraction(Set.of(FluidTags.WATER, FluidTags.LAVA));
      protected boolean wasTouchingWater;

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -26,15 +26,32 @@
      public static final float DEFAULT_BB_WIDTH = 0.6F;
      public static final float DEFAULT_BB_HEIGHT = 1.8F;
      public float moveDist;
-@@ -306,7 +_,7 @@
+@@ -299,14 +_,14 @@
+     public double zOld;
+     public boolean noPhysics;
+     protected final RandomSource random = SHARED_RANDOM; // Paper - Share random for entities to make them more random
+-    public int tickCount;
++    public int tickCount; // Gale - Event-driven - Cat.canRemoveWhenFarAway, Ocelot.canRemoveWhenFarAway - TODO Watch for new writes
+     private int remainingFireTicks;
+     private final EntityFluidInteraction fluidInteraction = new EntityFluidInteraction(Set.of(FluidTags.WATER, FluidTags.LAVA));
+     protected boolean wasTouchingWater;
      protected boolean wasEyeInWater;
      public int invulnerableTime;
      protected boolean firstTick = true;
 -    protected final SynchedEntityData entityData;
-+    protected final SynchedEntityData entityData; // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new writes
++    protected final SynchedEntityData entityData; // Gale - Event-driven - AbstractFish.canRemoveWhenFarAway, Axolotl.canRemoveWhenFarAway, Cat.canRemoveWhenFarAway, LivingEntity.isAlive, Mob.requiresCustomPersistence, Ocelot.canRemoveWhenFarAway, ZombieVillager.canRemoveWhenFarAway - TODO Watch for new writes
      protected static final EntityDataAccessor<Byte> DATA_SHARED_FLAGS_ID = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.BYTE);
      protected static final int FLAG_ONFIRE = 0;
      private static final int FLAG_SHIFT_KEY_DOWN = 1;
+@@ -316,7 +_,7 @@
+     protected static final int FLAG_GLOWING = 6;
+     protected static final int FLAG_FALL_FLYING = 7;
+     private static final EntityDataAccessor<Integer> DATA_AIR_SUPPLY_ID = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.INT);
+-    private static final EntityDataAccessor<Optional<Component>> DATA_CUSTOM_NAME = SynchedEntityData.defineId(
++    private static final EntityDataAccessor<Optional<Component>> DATA_CUSTOM_NAME = SynchedEntityData.defineId( // Gale - Event-driven - AbstractFish.canRemoveWhenFarAway, Axolotl.canRemoveWhenFarAway, Ocelot.canRemoveWhenFarAway - TODO Watch for new set calls
+         Entity.class, EntityDataSerializers.OPTIONAL_COMPONENT
+     );
+     private static final EntityDataAccessor<Boolean> DATA_CUSTOM_NAME_VISIBLE = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.BOOLEAN);
 @@ -474,10 +_,7 @@
  
      @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -172,7 +172,7 @@
                  // Paper start - Configurable despawn distances
                  final io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRangePair despawnRangePair = this.level().paperConfig().entities.spawning.despawnRanges.get(this.getType().getCategory());
                  final io.papermc.paper.configuration.type.DespawnRange.Shape shape = this.level().paperConfig().entities.spawning.despawnRangeShape;
-@@ -806,11 +_,11 @@
+@@ -806,12 +_,12 @@
                  final double dzSqr = Mth.square(player.getZ() - this.getZ());
                  final double distanceSquared = dxSqr + dzSqr + dySqr;
                  // Despawn if hard/soft limit is exceeded
@@ -182,10 +182,12 @@
                  }
  
 -                if (despawnRangePair.soft().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy)) {
-+                if (this.gale$canRemoveWhenFarAway() && despawnRangePair.soft().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy)) { // Gale - Optimize Mob.checkDespawn
-                     if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(distanceSquared)) {
+-                    if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(distanceSquared)) {
++                if (despawnRangePair.soft().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy)) { // Gale - Optimize Mob.checkDespawn
++                    if (this.gale$canRemoveWhenFarAway() && this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(distanceSquared)) {
                          this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
                      }
+                 } else {
 @@ -820,6 +_,7 @@
                  }
              }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -5,7 +5,7 @@
      private DropChances dropChances = DropChances.DEFAULT;
      private boolean canPickUpLoot = false;
 -    public boolean persistenceRequired = false;
-+    public boolean persistenceRequired = false; // Gale - Event-driven - Mob.isPersistent - TODO Watch for new writes
++    public boolean persistenceRequired = false; // Gale - Event-driven - Mob.isPersistent, Piglin.canRemoveWhenFarAway - TODO Watch for new writes
      private final Map<PathType, Float> pathfindingMalus = Maps.newEnumMap(PathType.class);
      public Optional<ResourceKey<LootTable>> lootTable = Optional.empty();
      public long lootTableSeed;
@@ -27,11 +27,12 @@
      }
  
      protected void registerGoals() {
-@@ -469,6 +_,7 @@
+@@ -469,6 +_,8 @@
          boolean persistenceRequired = input.getBooleanOr("PersistenceRequired", false);
          if (isLevelAtLeast(input, 1) || persistenceRequired) {
              this.persistenceRequired = persistenceRequired;
 +            this.gale$eventDriven_isPersistent_update(); // Gale - Event-driven - Mob.isPersistent
++           if (this instanceof net.minecraft.world.entity.monster.piglin.Piglin piglin) piglin.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Piglin.canRemoveWhenFarAway
          }
          // CraftBukkit end
          this.dropChances = input.read("drop_chances", DropChances.CODEC).orElse(DropChances.DEFAULT);
@@ -43,19 +44,31 @@
      }
      public static net.kyori.adventure.util.TriState readDespawnInPeacefulOverride(ValueInput input) {
          return input.read("Paper.DespawnInPeacefulOverride", io.papermc.paper.util.PaperCodecs.TRI_STATE_CODEC).orElse(net.kyori.adventure.util.TriState.NOT_SET);
-@@ -653,6 +_,7 @@
+@@ -653,6 +_,8 @@
              ItemStack toEquip = slot.limit(itemStack);
              this.setItemSlotAndDropWhenKilled(slot, toEquip);
              this.persistenceRequired = true;
 +            this.gale$eventDriven_isPersistent_update(); // Gale - Event-driven - Mob.isPersistent
++            if (this instanceof net.minecraft.world.entity.monster.piglin.Piglin piglin) piglin.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Piglin.canRemoveWhenFarAway
              return toEquip;
          } else {
              return ItemStack.EMPTY;
-@@ -780,23 +_,102 @@
+@@ -780,23 +_,113 @@
          return true;
      }
  
 -    public boolean requiresCustomPersistence() {
++    // Gale start - Optimize Mob.checkDespawn - Pre-check for removeWhenFarAway()
++    /**
++     * @return Whether it's currently possible for {@link #removeWhenFarAway(double)} to return true
++     * for some distance. In other words, this method returns false if {@link #removeWhenFarAway(double)} currently
++     * returns false for any given distance, and this method returns true if {@link #removeWhenFarAway(double)}
++     * may currently return true or false.
++     */
++    public boolean gale$canRemoveWhenFarAway() {
++        return this.removeWhenFarAway(-1);
++    }
++
 +    public boolean gale$eventDriven_requiresCustomPersistence_compute() { // Gale - Event-driven - Mob.requiresCustomPersistence
          return this.isPassenger() || this.isLeashed();
      }
@@ -120,7 +133,7 @@
 +    // Gale end - Event-driven - Mob.mustDespawnBecauseOfPeacefulDifficulty
 +
 +    // Gale start - Event-driven - Mob.isLeashed
-+    private boolean gale$eventDriven_isLeashed; // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new writes
++    protected boolean gale$eventDriven_isLeashed; // Gale - Event-driven - Mob.requiresCustomPersistence, Ocelot.canRemoveWhenFarAway - TODO Watch for new writes
 +    private java.lang.ref.@Nullable WeakReference<net.minecraft.world.entity.Mob> leashDataListenerReference;
 +
 +    public void gale$eventDriven_isLeashed_update() {
@@ -153,12 +166,26 @@
 -        } else if (!this.isPersistenceRequired() && !this.requiresCustomPersistence()) {
 +        } else if (!this.gale$eventDriven_isPersistent) { // Gale - Event-driven - Mob.isPersistent
 +            if (!org.galemc.gale.async.SimulationFlag.REAL) return; // Gale - Speculative execution based on next tick simulation - Simulate next tick
-+            if (this.level().gale$eventDriven_affectsSpawningSelectorPlayerCount != 0) { // Gale - Optimize checkDespawn
++            if (this.level().gale$eventDriven_affectsSpawningSelectorPlayerCount != 0) { // Gale - Optimize Mob.checkDespawn
              Entity player = this.level().findNearbyPlayer(this, -1.0, EntitySelector.PLAYER_AFFECTS_SPAWNING); // Paper - Affects Spawning API
 -            if (player != null) {
                  // Paper start - Configurable despawn distances
                  final io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRangePair despawnRangePair = this.level().paperConfig().entities.spawning.despawnRanges.get(this.getType().getCategory());
                  final io.papermc.paper.configuration.type.DespawnRange.Shape shape = this.level().paperConfig().entities.spawning.despawnRangeShape;
+@@ -806,11 +_,11 @@
+                 final double dzSqr = Mth.square(player.getZ() - this.getZ());
+                 final double distanceSquared = dxSqr + dzSqr + dySqr;
+                 // Despawn if hard/soft limit is exceeded
+-                if (despawnRangePair.hard().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy) && this.removeWhenFarAway(distanceSquared)) {
++                if (this.gale$canRemoveWhenFarAway() && despawnRangePair.hard().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy) && this.removeWhenFarAway(distanceSquared)) { // Gale - Optimize Mob.checkDespawn
+                     this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
+                 }
+ 
+-                if (despawnRangePair.soft().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy)) {
++                if (this.gale$canRemoveWhenFarAway() && despawnRangePair.soft().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy)) { // Gale - Optimize Mob.checkDespawn
+                     if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(distanceSquared)) {
+                         this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
+                     }
 @@ -820,6 +_,7 @@
                  }
              }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/TamableAnimal.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/TamableAnimal.java.patch
@@ -5,15 +5,7 @@
      private static final int MAX_VERTICAL_DISTANCE_FROM_TARGET_AFTER_TELEPORTING = 1;
      private static final boolean DEFAULT_ORDERED_TO_SIT = false;
 -    protected static final EntityDataAccessor<Byte> DATA_FLAGS_ID = SynchedEntityData.defineId(TamableAnimal.class, EntityDataSerializers.BYTE);
-+    protected static final EntityDataAccessor<Byte> DATA_FLAGS_ID = SynchedEntityData.defineId(TamableAnimal.class, EntityDataSerializers.BYTE); // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new writes
++    protected static final EntityDataAccessor<Byte> DATA_FLAGS_ID = SynchedEntityData.defineId(TamableAnimal.class, EntityDataSerializers.BYTE); // Gale - Event-driven - Cat.canRemoveWhenFarAway, Mob.requiresCustomPersistence - TODO Watch for new set calls
      protected static final EntityDataAccessor<Optional<EntityReference<LivingEntity>>> DATA_OWNERUUID_ID = SynchedEntityData.defineId(
          TamableAnimal.class, EntityDataSerializers.OPTIONAL_LIVING_ENTITY_REFERENCE
      );
-@@ -123,6 +_,7 @@
-         } else {
-             this.entityData.set(DATA_FLAGS_ID, (byte)(current & -5));
-         }
-+        this.gale$eventDriven_requiresCustomPersistence_update(); // Gale - Event-driven - Mob.requiresCustomPersistence
- 
-         if (includeSideEffects) {
-             this.applyTamingSideEffects();

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/axolotl/Axolotl.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/axolotl/Axolotl.java.patch
@@ -5,22 +5,24 @@
      private static final EntityDataAccessor<Integer> DATA_VARIANT = SynchedEntityData.defineId(Axolotl.class, EntityDataSerializers.INT);
      private static final EntityDataAccessor<Boolean> DATA_PLAYING_DEAD = SynchedEntityData.defineId(Axolotl.class, EntityDataSerializers.BOOLEAN);
 -    private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(Axolotl.class, EntityDataSerializers.BOOLEAN);
-+    private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(Axolotl.class, EntityDataSerializers.BOOLEAN); // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new writes
++    private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(Axolotl.class, EntityDataSerializers.BOOLEAN); // Gale - Event-driven - Axolotl.canRemoveWhenFarAway, Mob.requiresCustomPersistence - TODO Watch for new set calls
      public static final double PLAYER_REGEN_DETECTION_RANGE = 20.0;
      public static final int RARE_VARIANT_CHANCE = 1200;
      private static final int AXOLOTL_TOTAL_AIR_SUPPLY = 6000;
-@@ -120,6 +_,7 @@
+@@ -120,6 +_,8 @@
          this.setPathfindingMalus(PathType.WATER, 0.0F);
          this.moveControl = new Axolotl.AxolotlMoveControl<>(this);
          this.lookControl = new Axolotl.AxolotlLookControl(this, 20);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Axolotl.canRemoveWhenFarAway
 +        this.gale$eventDriven_requiresCustomPersistence_update(); // Gale - Event-driven - Mob.requiresCustomPersistence
      }
  
      @Override
-@@ -336,6 +_,7 @@
+@@ -336,6 +_,8 @@
      @Override
      public void setFromBucket(final boolean fromBucket) {
          this.entityData.set(FROM_BUCKET, fromBucket);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Axolotl.canRemoveWhenFarAway
 +        this.gale$eventDriven_requiresCustomPersistence_update(); // Gale - Event-driven - Mob.requiresCustomPersistence
      }
  
@@ -38,3 +40,28 @@
      }
  
      @Override
+@@ -552,6 +_,24 @@
+ 
+     @Override
+     public boolean removeWhenFarAway(final double distSqr) {
++        // Gale start - Event-driven - Axolotl.canRemoveWhenFarAway
++        return this.gale$eventDriven_canRemoveWhenFarAway;
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway;
++
++    public void gale$eventDriven_canRemoveWhenFarAway_update() {
++        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++    }
++
++    @Override
++    public void setCustomName(final net.minecraft.network.chat.@org.jspecify.annotations.Nullable Component name) {
++        super.setCustomName(name);
++        this.gale$eventDriven_canRemoveWhenFarAway_update();
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {
++        // Gale end - Event-driven - Axolotl.canRemoveWhenFarAway
+         return !this.fromBucket() && !this.hasCustomName();
+     }
+ 

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/chicken/Chicken.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/chicken/Chicken.java.patch
@@ -1,0 +1,51 @@
+--- a/net/minecraft/world/entity/animal/chicken/Chicken.java
++++ b/net/minecraft/world/entity/animal/chicken/Chicken.java
+@@ -73,12 +_,13 @@
+     public float flapping = 1.0F;
+     private float nextFlap = 1.0F;
+     public int eggTime;
+-    public boolean isChickenJockey = false;
++    public boolean isChickenJockey = false; // Gale - Event-driven - Chicken.canRemoveWhenFarAway - TODO Watch for new writes
+ 
+     public Chicken(final EntityType<? extends Chicken> type, final Level level) {
+         super(type, level);
+         this.eggTime = this.random.nextInt(6000) + 6000;
+         this.setPathfindingMalus(PathType.WATER, 0.0F);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Chicken.canRemoveWhenFarAway
+     }
+ 
+     @Override
+@@ -213,6 +_,7 @@
+     protected void readAdditionalSaveData(final ValueInput input) {
+         super.readAdditionalSaveData(input);
+         this.isChickenJockey = input.getBooleanOr("IsChickenJockey", false);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Chicken.canRemoveWhenFarAway
+         input.getInt("EggLayTime").ifPresent(time -> this.eggTime = time);
+         VariantUtils.readVariant(input, Registries.CHICKEN_VARIANT).ifPresent(this::setVariant);
+         input.read("sound_variant", ResourceKey.codec(Registries.CHICKEN_SOUND_VARIANT))
+@@ -274,6 +_,18 @@
+ 
+     @Override
+     public boolean removeWhenFarAway(final double distSqr) {
++        // Gale start - Event-driven - Chicken.canRemoveWhenFarAway
++        return this.gale$eventDriven_canRemoveWhenFarAway;
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway;
++
++    public void gale$eventDriven_canRemoveWhenFarAway_update() {
++        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {
++        // Gale end - Event-driven - Chicken.canRemoveWhenFarAway
+         return this.isChickenJockey();
+     }
+ 
+@@ -291,5 +_,6 @@
+ 
+     public void setChickenJockey(final boolean isChickenJockey) {
+         this.isChickenJockey = isChickenJockey;
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Chicken.canRemoveWhenFarAway
+     }
+ }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Cat.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Cat.java.patch
@@ -8,7 +8,7 @@
      }
  
      @Override
-@@ -467,12 +_,25 @@
+@@ -467,12 +_,37 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
@@ -21,6 +21,18 @@
 +
 +    public void gale$eventDriven_canRemoveWhenFarAway_update() {
 +        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++    }
++
++    @Override
++    public void postTick() {
++        super.postTick();
++        if (this.gale$eventDriven_canRemoveWhenFarAway && this.tickCount > 2400) this.gale$eventDriven_canRemoveWhenFarAway_update();
++    }
++
++    @Override
++    public void inactiveTick() {
++        super.inactiveTick();
++        if (this.gale$eventDriven_canRemoveWhenFarAway && this.tickCount > 2400) this.gale$eventDriven_canRemoveWhenFarAway_update();
 +    }
 +
 +    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Cat.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Cat.java.patch
@@ -1,0 +1,37 @@
+--- a/net/minecraft/world/entity/animal/feline/Cat.java
++++ b/net/minecraft/world/entity/animal/feline/Cat.java
+@@ -100,6 +_,7 @@
+     public Cat(final EntityType<? extends Cat> type, final Level level) {
+         super(type, level);
+         this.reassessTameGoals();
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Cat.canRemoveWhenFarAway
+     }
+ 
+     @Override
+@@ -467,12 +_,25 @@
+ 
+     @Override
+     public boolean removeWhenFarAway(final double distSqr) {
+-        return !this.isTame() && this.tickCount > 2400;
++        // Gale start - Event-driven - Cat.canRemoveWhenFarAway
++        return this.gale$eventDriven_canRemoveWhenFarAway;
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway;
++
++    public void gale$eventDriven_canRemoveWhenFarAway_update() {
++        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {
++        return this.tickCount > 2400 && !this.isTame(); // Re-order checks
++        // Gale end - Event-driven - Cat.canRemoveWhenFarAway
+     }
+ 
+     @Override
+     public void setTame(final boolean isTame, final boolean includeSideEffects) {
+         super.setTame(isTame, includeSideEffects);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Cat.canRemoveWhenFarAway
+         this.reassessTameGoals();
+     }
+ 

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Cat.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Cat.java.patch
@@ -8,7 +8,7 @@
      }
  
      @Override
-@@ -467,12 +_,37 @@
+@@ -467,12 +_,34 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
@@ -24,15 +24,12 @@
 +    }
 +
 +    @Override
-+    public void postTick() {
-+        super.postTick();
-+        if (this.gale$eventDriven_canRemoveWhenFarAway && this.tickCount > 2400) this.gale$eventDriven_canRemoveWhenFarAway_update();
-+    }
-+
-+    @Override
-+    public void inactiveTick() {
-+        super.inactiveTick();
-+        if (this.gale$eventDriven_canRemoveWhenFarAway && this.tickCount > 2400) this.gale$eventDriven_canRemoveWhenFarAway_update();
++    public void setTickCount(int tickCount) {
++        int oldTickCount = this.tickCount;
++        super.setTickCount(tickCount);
++        if ((tickCount > 2400) != (oldTickCount > 2400)) {
++            this.gale$eventDriven_canRemoveWhenFarAway_update();
++        }
 +    }
 +
 +    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
@@ -25,7 +25,7 @@
          this.reassessTrustingGoals();
      }
  
-@@ -136,7 +_,47 @@
+@@ -136,7 +_,44 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
@@ -57,15 +57,12 @@
 +    }
 +
 +    @Override
-+    public void postTick() {
-+        super.postTick();
-+        if (this.gale$eventDriven_canRemoveWhenFarAway && this.tickCount > 2400) this.gale$eventDriven_canRemoveWhenFarAway_update();
-+    }
-+
-+    @Override
-+    public void inactiveTick() {
-+        super.inactiveTick();
-+        if (this.gale$eventDriven_canRemoveWhenFarAway && this.tickCount > 2400) this.gale$eventDriven_canRemoveWhenFarAway_update();
++    public void setTickCount(int tickCount) {
++        int oldTickCount = this.tickCount;
++        super.setTickCount(tickCount);
++        if ((tickCount > 2400) != (oldTickCount > 2400)) {
++            this.gale$eventDriven_canRemoveWhenFarAway_update();
++        }
 +    }
 +
 +    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
@@ -25,10 +25,11 @@
          this.reassessTrustingGoals();
      }
  
-@@ -136,6 +_,34 @@
+@@ -136,7 +_,47 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
+-        return !this.isTrusting() && this.tickCount > 2400 && !this.hasCustomName() && !this.isLeashed(); // Paper - honor name and leash
 +        // Gale start - Event-driven - Ocelot.canRemoveWhenFarAway
 +        return this.gale$eventDriven_canRemoveWhenFarAway;
 +    }
@@ -55,8 +56,21 @@
 +        }
 +    }
 +
++    @Override
++    public void postTick() {
++        super.postTick();
++        if (this.gale$eventDriven_canRemoveWhenFarAway && this.tickCount > 2400) this.gale$eventDriven_canRemoveWhenFarAway_update();
++    }
++
++    @Override
++    public void inactiveTick() {
++        super.inactiveTick();
++        if (this.gale$eventDriven_canRemoveWhenFarAway && this.tickCount > 2400) this.gale$eventDriven_canRemoveWhenFarAway_update();
++    }
++
 +    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {
++        return this.tickCount > 2400 && !this.isLeashed() && !this.isTrusting() && !this.hasCustomName(); // Paper - honor name and leash // Re-order checks
 +        // Gale end - Event-driven - Ocelot.canRemoveWhenFarAway
-         return !this.isTrusting() && this.tickCount > 2400 && !this.hasCustomName() && !this.isLeashed(); // Paper - honor name and leash
      }
  
+     public static AttributeSupplier.Builder createAttributes() {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
@@ -1,0 +1,62 @@
+--- a/net/minecraft/world/entity/animal/feline/Ocelot.java
++++ b/net/minecraft/world/entity/animal/feline/Ocelot.java
+@@ -60,7 +_,7 @@
+     public static final double CROUCH_SPEED_MOD = 0.6;
+     public static final double WALK_SPEED_MOD = 0.8;
+     public static final double SPRINT_SPEED_MOD = 1.33;
+-    private static final EntityDataAccessor<Boolean> DATA_TRUSTING = SynchedEntityData.defineId(Ocelot.class, EntityDataSerializers.BOOLEAN);
++    private static final EntityDataAccessor<Boolean> DATA_TRUSTING = SynchedEntityData.defineId(Ocelot.class, EntityDataSerializers.BOOLEAN); // Gale - Event-driven - Ocelot.canRemoveWhenFarAway - TODO Watch for new set calls
+     private static final boolean DEFAULT_TRUSTING = false;
+     private static final EntityDimensions BABY_DIMENSIONS = EntityDimensions.scalable(0.3F, 0.35F)
+         .withEyeHeight(0.34375F)
+@@ -71,6 +_,7 @@
+     public Ocelot(final EntityType<? extends Ocelot> type, final Level level) {
+         super(type, level);
+         this.reassessTrustingGoals();
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Ocelot.canRemoveWhenFarAway
+     }
+ 
+     public boolean isTrusting() {
+@@ -79,6 +_,7 @@
+ 
+     public void setTrusting(final boolean trusting) {
+         this.entityData.set(DATA_TRUSTING, trusting);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Ocelot.canRemoveWhenFarAway
+         this.reassessTrustingGoals();
+     }
+ 
+@@ -136,6 +_,34 @@
+ 
+     @Override
+     public boolean removeWhenFarAway(final double distSqr) {
++        // Gale start - Event-driven - Ocelot.canRemoveWhenFarAway
++        return this.gale$eventDriven_canRemoveWhenFarAway;
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway;
++
++    public void gale$eventDriven_canRemoveWhenFarAway_update() {
++        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++    }
++
++    @Override
++    public void setCustomName(final net.minecraft.network.chat.@org.jspecify.annotations.Nullable Component name) {
++        super.setCustomName(name);
++        this.gale$eventDriven_canRemoveWhenFarAway_update();
++    }
++
++    @Override
++    public void gale$eventDriven_isLeashed_update() {
++        boolean oldValue = this.gale$eventDriven_isLeashed;
++        super.gale$eventDriven_isLeashed_update();
++        boolean newValue = this.gale$eventDriven_isLeashed;
++        if (newValue != oldValue) {
++            this.gale$eventDriven_canRemoveWhenFarAway_update();
++        }
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {
++        // Gale end - Event-driven - Ocelot.canRemoveWhenFarAway
+         return !this.isTrusting() && this.tickCount > 2400 && !this.hasCustomName() && !this.isLeashed(); // Paper - honor name and leash
+     }
+ 

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/fish/AbstractFish.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/fish/AbstractFish.java.patch
@@ -1,21 +1,22 @@
 --- a/net/minecraft/world/entity/animal/fish/AbstractFish.java
 +++ b/net/minecraft/world/entity/animal/fish/AbstractFish.java
-@@ -33,12 +_,13 @@
+@@ -33,12 +_,14 @@
  import net.minecraft.world.phys.Vec3;
  
  public abstract class AbstractFish extends WaterAnimal implements Bucketable {
 -    private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(AbstractFish.class, EntityDataSerializers.BOOLEAN);
-+    private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(AbstractFish.class, EntityDataSerializers.BOOLEAN); // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new writes
++    private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(AbstractFish.class, EntityDataSerializers.BOOLEAN); // Gale - Event-driven - AbstractFish.canRemoveWhenFarAway, Mob.requiresCustomPersistence - TODO Watch for new set calls
      private static final boolean DEFAULT_FROM_BUCKET = false;
  
      public AbstractFish(final EntityType<? extends AbstractFish> type, final Level level) {
          super(type, level);
          this.moveControl = new AbstractFish.FishMoveControl<>(this);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - AbstractFish.canRemoveWhenFarAway
 +        this.gale$eventDriven_requiresCustomPersistence_update(); // Gale - Event-driven - Mob.requiresCustomPersistence
      }
  
      public static AttributeSupplier.Builder createAttributes() {
-@@ -46,8 +_,10 @@
+@@ -46,12 +_,32 @@
      }
  
      @Override
@@ -28,10 +29,33 @@
      }
  
      @Override
-@@ -74,6 +_,7 @@
+     public boolean removeWhenFarAway(final double distSqr) {
++        // Gale start - Event-driven - AbstractFish.canRemoveWhenFarAway
++        return this.gale$eventDriven_canRemoveWhenFarAway;
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway;
++
++    public void gale$eventDriven_canRemoveWhenFarAway_update() {
++        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++    }
++
++    @Override
++    public void setCustomName(final net.minecraft.network.chat.@org.jspecify.annotations.Nullable Component name) {
++        super.setCustomName(name);
++        this.gale$eventDriven_canRemoveWhenFarAway_update();
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {
++        // Gale end - Event-driven - AbstractFish.canRemoveWhenFarAway
+         return !this.fromBucket() && !this.hasCustomName();
+     }
+ 
+@@ -74,6 +_,8 @@
      @Override
      public void setFromBucket(final boolean fromBucket) {
          this.entityData.set(FROM_BUCKET, fromBucket);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - AbstractFish.canRemoveWhenFarAway
 +        this.gale$eventDriven_requiresCustomPersistence_update(); // Gale - Event-driven - Mob.requiresCustomPersistence
      }
  

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/nautilus/AbstractNautilus.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/nautilus/AbstractNautilus.java.patch
@@ -8,13 +8,19 @@
      }
  
      @Override
-@@ -535,7 +_,9 @@
+@@ -535,7 +_,15 @@
      }
  
      @Override
 -    public boolean requiresCustomPersistence() {
 -        return super.requiresCustomPersistence() || this.isTame();
 +    // Gale start - Event-driven - Mob.requiresCustomPersistence
++    public void setTame(final boolean isTame, final boolean includeSideEffects) {
++        super.setTame(isTame, includeSideEffects);
++        this.gale$eventDriven_requiresCustomPersistence_update(); // Gale - Event-driven - Mob.requiresCustomPersistence
++    }
++
++    @Override
 +    public boolean gale$eventDriven_requiresCustomPersistence_compute() {
 +        return super.gale$eventDriven_requiresCustomPersistence_compute() || this.isTame();
 +        // Gale end - Event-driven - Mob.requiresCustomPersistence

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/EnderMan.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/EnderMan.java.patch
@@ -5,7 +5,7 @@
      private static final int DELAY_BETWEEN_CREEPY_STARE_SOUND = 400;
      private static final int MIN_DEAGGRESSION_TIME = 600;
 -    private static final EntityDataAccessor<Optional<BlockState>> DATA_CARRY_STATE = SynchedEntityData.defineId(
-+    private static final EntityDataAccessor<Optional<BlockState>> DATA_CARRY_STATE = SynchedEntityData.defineId( // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new writes
++    private static final EntityDataAccessor<Optional<BlockState>> DATA_CARRY_STATE = SynchedEntityData.defineId( // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new set calls
          EnderMan.class, EntityDataSerializers.OPTIONAL_BLOCK_STATE
      );
      private static final EntityDataAccessor<Boolean> DATA_CREEPY = SynchedEntityData.defineId(EnderMan.class, EntityDataSerializers.BOOLEAN);

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/PatrollingMonster.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/PatrollingMonster.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/world/entity/monster/PatrollingMonster.java
++++ b/net/minecraft/world/entity/monster/PatrollingMonster.java
+@@ -99,6 +_,13 @@
+         return !this.patrolling || distSqr > 16384.0;
+     }
+ 
++    // Gale start - Optimize Mob.checkDespawn - Pre-check for removeWhenFarAway()
++    @Override
++    public boolean gale$canRemoveWhenFarAway() {
++        return true;
++    }
++    // Gale end - Optimize Mob.checkDespawn - Pre-check for removeWhenFarAway()
++
+     public void setPatrolTarget(final BlockPos target) {
+         this.patrolTarget = target;
+         this.patrolling = true;

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
@@ -5,7 +5,7 @@
      private List<SulfurCubeArchetype.ContactDamage> contactDamages = new ArrayList<>();
      public static final EntityDataAccessor<Integer> MAX_FUSE = SynchedEntityData.defineId(SulfurCube.class, EntityDataSerializers.INT);
 -    private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(SulfurCube.class, EntityDataSerializers.BOOLEAN);
-+    private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(SulfurCube.class, EntityDataSerializers.BOOLEAN); // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new writes
++    private static final EntityDataAccessor<Boolean> FROM_BUCKET = SynchedEntityData.defineId(SulfurCube.class, EntityDataSerializers.BOOLEAN); // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new set calls
      private static final boolean DEFAULT_FROM_BUCKET = false;
      private static final float HORIZONTAL_HIT_ANGLE_SCALE = 1.6F;
      private static final float VERTICAL_HIT_ANGLE_SCALE = 0.5F;

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
@@ -1,0 +1,35 @@
+--- a/net/minecraft/world/entity/monster/piglin/Piglin.java
++++ b/net/minecraft/world/entity/monster/piglin/Piglin.java
+@@ -107,6 +_,7 @@
+     public Piglin(final EntityType<? extends AbstractPiglin> type, final Level level) {
+         super(type, level);
+         this.xpReward = 5;
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Piglin.canRemoveWhenFarAway
+     }
+ 
+     @Override
+@@ -207,6 +_,24 @@
+ 
+     @Override
+     public boolean removeWhenFarAway(final double distSqr) {
++        // Gale start - Event-driven - Piglin.canRemoveWhenFarAway
++        return this.gale$eventDriven_canRemoveWhenFarAway;
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway;
++
++    public void gale$eventDriven_canRemoveWhenFarAway_update() {
++        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++    }
++
++    @Override
++    public void setPersistenceRequired() {
++        super.setPersistenceRequired();
++        this.gale$eventDriven_canRemoveWhenFarAway_update();
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {
++        // Gale end - Event-driven - Piglin.canRemoveWhenFarAway
+         return !this.isPersistenceRequired();
+     }
+ 

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/zombie/ZombieVillager.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/zombie/ZombieVillager.java.patch
@@ -1,0 +1,70 @@
+--- a/net/minecraft/world/entity/monster/zombie/ZombieVillager.java
++++ b/net/minecraft/world/entity/monster/zombie/ZombieVillager.java
+@@ -61,7 +_,7 @@
+ import org.jspecify.annotations.Nullable;
+ 
+ public class ZombieVillager extends Zombie implements VillagerDataHolder {
+-    public static final EntityDataAccessor<Boolean> DATA_CONVERTING_ID = SynchedEntityData.defineId(ZombieVillager.class, EntityDataSerializers.BOOLEAN);
++    public static final EntityDataAccessor<Boolean> DATA_CONVERTING_ID = SynchedEntityData.defineId(ZombieVillager.class, EntityDataSerializers.BOOLEAN); // Gale - Event-driven - ZombieVillager.canRemoveWhenFarAway - TODO Watch for new set calls
+     private static final EntityDataAccessor<VillagerData> DATA_VILLAGER_DATA = SynchedEntityData.defineId(
+         ZombieVillager.class, EntityDataSerializers.VILLAGER_DATA
+     );
+@@ -78,13 +_,14 @@
+     public @Nullable UUID conversionStarter;
+     private @Nullable GossipContainer gossips;
+     private @Nullable MerchantOffers tradeOffers;
+-    private int villagerXp = 0;
++    private int villagerXp = 0; // Gale - Event-driven - ZombieVillager.canRemoveWhenFarAway - TODO Watch for new writes
+     private static final EntityDimensions BABY_DIMENSIONS = EntityDimensions.scalable(0.49F, 0.98F)
+         .withEyeHeight(0.67F)
+         .withAttachments(EntityAttachments.builder().attach(EntityAttachment.VEHICLE, 0.0F, 0.125F, 0.0F));
+ 
+     public ZombieVillager(final EntityType<? extends ZombieVillager> type, final Level level) {
+         super(type, level);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - ZombieVillager.canRemoveWhenFarAway
+     }
+ 
+     @Override
+@@ -129,6 +_,7 @@
+         }
+ 
+         this.villagerXp = input.getIntOr("Xp", 0);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - ZombieVillager.canRemoveWhenFarAway
+     }
+ 
+     @Override
+@@ -188,6 +_,18 @@
+ 
+     @Override
+     public boolean removeWhenFarAway(final double distSqr) {
++        // Gale start - Event-driven - ZombieVillager.canRemoveWhenFarAway
++        return this.gale$eventDriven_canRemoveWhenFarAway;
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway;
++
++    public void gale$eventDriven_canRemoveWhenFarAway_update() {
++        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {
++        // Gale end - Event-driven - ZombieVillager.canRemoveWhenFarAway
+         return !this.isConverting() && this.villagerXp == 0;
+     }
+ 
+@@ -205,6 +_,7 @@
+         this.conversionStarter = player;
+         this.villagerConversionTime = time;
+         this.getEntityData().set(DATA_CONVERTING_ID, true);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - ZombieVillager.canRemoveWhenFarAway
+         // CraftBukkit start
+         this.removeEffect(MobEffects.WEAKNESS, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.CONVERSION);
+         this.addEffect(new MobEffectInstance(MobEffects.STRENGTH, time, Math.min(this.level().getDifficulty().getId() - 1, 0)), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.CONVERSION);
+@@ -382,6 +_,7 @@
+ 
+     public void setVillagerXp(final int villagerXp) {
+         this.villagerXp = villagerXp;
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - ZombieVillager.canRemoveWhenFarAway
+     }
+ 
+     @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
-@@ -172,9 +_,39 @@
+@@ -172,9 +_,54 @@
      private Optional<GlobalPos> lastDeathLocation = Optional.empty();
      public @Nullable FishingHook fishing;
      public float hurtDir;

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raider.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raider.java.patch
@@ -1,36 +1,65 @@
 --- a/net/minecraft/world/entity/raid/Raider.java
 +++ b/net/minecraft/world/entity/raid/Raider.java
-@@ -50,7 +_,7 @@
+@@ -50,13 +_,15 @@
          && ItemStack.matches(e.getItem(), Raid.getOminousBannerInstance(e.registryAccess().lookupOrThrow(Registries.BANNER_PATTERN)));
      private static final int DEFAULT_WAVE = 0;
      private static final boolean DEFAULT_CAN_JOIN_RAID = false;
 -    protected @Nullable Raid raid;
-+    protected @Nullable Raid raid; // Gale - Event-driven - Mob.requiresCustomPersistence - TODO Watch for new writes
++    protected @Nullable Raid raid; // Gale - Event-driven - Mob.requiresCustomPersistence, Raider.canRemoveWhenFarAway - TODO Watch for new writes
      private int wave = 0;
      private boolean canJoinRaid = false;
      private int ticksOutsideRaid;
-@@ -141,6 +_,7 @@
+ 
+     protected Raider(final EntityType<? extends Raider> type, final Level level) {
+         super(type, level);
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Raider.canRemoveWhenFarAway
++        this.gale$eventDriven_requiresCustomPersistence_update(); // Gale - Event-driven - Mob.requiresCustomPersistence
+     }
+ 
+     @Override
+@@ -141,6 +_,8 @@
  
      public void setCurrentRaid(final @Nullable Raid raid) {
          this.raid = raid;
++        this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Raider.canRemoveWhenFarAway
 +        this.gale$eventDriven_requiresCustomPersistence_update(); // Gale - Event-driven - Mob.requiresCustomPersistence
      }
  
      public @Nullable Raid getCurrentRaid() {
-@@ -197,6 +_,7 @@
+@@ -197,6 +_,8 @@
          if (this.level() instanceof ServerLevel level) {
              input.getInt("RaidId").ifPresent(raidId -> {
                  this.raid = level.getRaids().get(raidId);
++                this.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Raider.canRemoveWhenFarAway
 +                this.gale$eventDriven_requiresCustomPersistence_update(); // Gale - Event-driven - Mob.requiresCustomPersistence
                  if (this.raid != null) {
                      this.raid.addWaveMob(level, this.wave, this, false);
                      if (this.isPatrolLeader()) {
-@@ -243,8 +_,10 @@
+@@ -242,9 +_,28 @@
+         return this.getCurrentRaid() == null && super.removeWhenFarAway(distSqr);
      }
  
-     @Override
+-    @Override
 -    public boolean requiresCustomPersistence() {
 -        return super.requiresCustomPersistence() || this.getCurrentRaid() != null;
++    // Gale start - Event-driven - Raider.canRemoveWhenFarAway
++    @Override
++    public boolean gale$canRemoveWhenFarAway() {
++        return this.gale$eventDriven_canRemoveWhenFarAway;
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway;
++
++    public void gale$eventDriven_canRemoveWhenFarAway_update() {
++        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++    }
++
++    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {
++        return this.getCurrentRaid() == null;
++    }
++    // Gale end - Event-driven - Raider.canRemoveWhenFarAway
++
++    @Override
 +    // Gale start - Event-driven - Mob.requiresCustomPersistence
 +    public boolean gale$eventDriven_requiresCustomPersistence_compute() {
 +        return super.gale$eventDriven_requiresCustomPersistence_compute() || this.getCurrentRaid() != null;

--- a/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java.patch
+++ b/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java.patch
@@ -32,6 +32,15 @@
      }
  
      public static <T extends Entity> CraftEntity getEntity(CraftServer server, T entity) {
+@@ -579,6 +_,8 @@
+     public void setTicksLived(int value) {
+         Preconditions.checkArgument(value > 0, "Age value (%s) must be greater than 0", value);
+         this.getHandle().tickCount = value;
++        if (this.getHandle() instanceof net.minecraft.world.entity.animal.feline.Cat cat) cat.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Cat.canRemoveWhenFarAway
++        else if (this.getHandle() instanceof net.minecraft.world.entity.animal.feline.Ocelot ocelot) ocelot.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Ocelot.canRemoveWhenFarAway
+         this.getHandle().totalEntityAge = value;
+     }
+ 
 @@ -726,6 +_,20 @@
          return this.getHandle().visibleByDefault;
      }

--- a/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java.patch
+++ b/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java.patch
@@ -32,12 +32,12 @@
      }
  
      public static <T extends Entity> CraftEntity getEntity(CraftServer server, T entity) {
-@@ -579,6 +_,8 @@
+@@ -578,7 +_,7 @@
+     @Override
      public void setTicksLived(int value) {
          Preconditions.checkArgument(value > 0, "Age value (%s) must be greater than 0", value);
-         this.getHandle().tickCount = value;
-+        if (this.getHandle() instanceof net.minecraft.world.entity.animal.feline.Cat cat) cat.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Cat.canRemoveWhenFarAway
-+        else if (this.getHandle() instanceof net.minecraft.world.entity.animal.feline.Ocelot ocelot) ocelot.gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - Ocelot.canRemoveWhenFarAway
+-        this.getHandle().tickCount = value;
++        this.getHandle().setTickCount(value); // Gale - Event-driven - Cat.canRemoveWhenFarAway, Ocelot.canRemoveWhenFarAway
          this.getHandle().totalEntityAge = value;
      }
  

--- a/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java.patch
+++ b/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java.patch
@@ -1,15 +1,19 @@
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -697,7 +_,11 @@
+@@ -697,7 +_,15 @@
      @Override
      public void setRemoveWhenFarAway(boolean remove) {
          if (this.getHandle() instanceof Mob mob) {
 -            mob.persistenceRequired = !remove;
-+            // Gale start - Event-driven - Mob.isPersistent
++            // Gale start - Event-driven - Mob.isPersistent, Piglin.canRemoveWhenFarAway
 +            boolean persistenceRequired = !remove;
-+            mob.persistenceRequired = persistenceRequired;
-+            mob.gale$eventDriven_isPersistent_update();
-+            // Gale end - Event-driven - Mob.isPersistent
++            if (persistenceRequired != mob.persistenceRequired) {
++                mob.persistenceRequired = persistenceRequired;
++                mob.gale$eventDriven_isPersistent_update();
++                if (mob instanceof net.minecraft.world.entity.monster.piglin.Piglin piglin)
++                    piglin.gale$eventDriven_canRemoveWhenFarAway_update();
++            }
++            // Gale end - Event-driven - Mob.isPersistent, Piglin.canRemoveWhenFarAway
          }
      }
  

--- a/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftVillagerZombie.java.patch
+++ b/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftVillagerZombie.java.patch
@@ -1,0 +1,10 @@
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillagerZombie.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillagerZombie.java
+@@ -65,6 +_,7 @@
+         if (time < 0) {
+             this.getHandle().setVillagerConversionTime(-1);
+             this.getHandle().getEntityData().set(net.minecraft.world.entity.monster.zombie.ZombieVillager.DATA_CONVERTING_ID, false);
++            this.getHandle().gale$eventDriven_canRemoveWhenFarAway_update(); // Gale - Event-driven - ZombieVillager.canRemoveWhenFarAway
+             this.getHandle().conversionStarter = null;
+             this.getHandle().removeEffect(MobEffects.STRENGTH, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.CONVERSION);
+         } else {


### PR DESCRIPTION
Create a new event-driven method `Mob.gale$canRemoveWhenFarAway`

This method is mostly for future use, but it can now be used as a pre-check before comparing distances in `Mob.checkDespawn`