### PR TITLE
Server crash error during corrupted chunk loading.

### DIFF
--- a/gale-server/src/main/java/org/galemc/gale/registry/blockstate/BlockStateIdMapper.java
+++ b/gale-server/src/main/java/org/galemc/gale/registry/blockstate/BlockStateIdMapper.java
@@ -38,7 +38,7 @@ public class BlockStateIdMapper implements IdMap<BlockState> {
 
     @Override
     public final @Nullable BlockState byId(final int id) {
-        return this.idToT.get(id);
+        return id >= 0 && id < this.idToT.size() ? this.idToT.get(id) : null;
     }
 
     @Override

--- a/patches/server/0092-Cache-CubeVoxelShape-shape-array.patch
+++ b/patches/server/0092-Cache-CubeVoxelShape-shape-array.patch
@@ -39,7 +39,7 @@ index 110405e6e70d980d3e09f04d79562b32a7413071..80ac976e1fcf8b9e584a19aad03b204b
 +        if (this.list == null) {
 +            this.list = new DoubleList[Direction.Axis.VALUES.length];
 +            for (Direction.Axis existingAxis : Direction.Axis.VALUES) {
-+                this.list[existingAxis.ordinal()] = new CubePointRange(this.shape.getSize(existingAxis));
++                this.list[existingAxis.ordinal()] = new CubePointRange(this.shape.getSize(axis));
 +            }
 +        }
 +        return this.list[axis.ordinal()];

--- a/patches/server/0092-Cache-CubeVoxelShape-shape-array.patch
+++ b/patches/server/0092-Cache-CubeVoxelShape-shape-array.patch
@@ -39,7 +39,7 @@ index 110405e6e70d980d3e09f04d79562b32a7413071..80ac976e1fcf8b9e584a19aad03b204b
 +        if (this.list == null) {
 +            this.list = new DoubleList[Direction.Axis.VALUES.length];
 +            for (Direction.Axis existingAxis : Direction.Axis.VALUES) {
-+                this.list[existingAxis.ordinal()] = new CubePointRange(this.shape.getSize(axis));
++                this.list[existingAxis.ordinal()] = new CubePointRange(this.shape.getSize(existingAxis));
 +            }
 +        }
 +        return this.list[axis.ordinal()];


### PR DESCRIPTION
Although Gale's system returned null when a stack with an invalid block state ID was loaded, causing the server to crash with exceprion, Gale's modification resulted in a backward-compatible core fix that prevented the crash.