### PR TITLE
Server crash error during corrupted chunk loading.

### DIFF
--- a/gale-server/src/main/java/org/galemc/gale/registry/blockstate/BlockStateIdMapper.java
+++ b/gale-server/src/main/java/org/galemc/gale/registry/blockstate/BlockStateIdMapper.java
@@ -38,7 +38,7 @@ public class BlockStateIdMapper implements IdMap<BlockState> {
 
     @Override
     public final @Nullable BlockState byId(final int id) {
-        return this.idToT.get(id);
+        return id >= 0 && id < this.idToT.size() ? this.idToT.get(id) : null;
     }
 
     @Override


### PR DESCRIPTION
When a chunk with an invalid block state ID is loaded, Gale's system code should return null and ignore the problem, but instead it throws an exception and crashes the server. Gale's modification changed it to a crash. This is a simple, backward-compatible fix.