### PR TITLE
Create event-driven Mob.checkDespawnPlayerTrackingMode

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Mob.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Mob.java.patch
@@ -19,10 +19,11 @@
  
      protected Mob(final EntityType<? extends Mob> type, final Level level) {
          super(type, level);
-@@ -169,6 +_,8 @@
+@@ -169,6 +_,9 @@
          if (level instanceof ServerLevel) {
              this.registerGoals();
          }
++        this.gale$eventDriven_checkDespawnPlayerTrackingMode_update(); // Gale - Event-driven - Mob.checkDespawnPlayerTrackingMode
 +        this.gale$eventDriven_despawnRanges_and_despawnRangeShape_update(); // Gale - Event-driven - Mob.despawnRanges, Mob.despawnRangeShape
 +        this.gale$eventDriven_mustDespawnBecauseOfPeacefulDifficulty_update(); // Gale - Event-driven - Mob.mustDespawnBecauseOfPeacefulDifficulty
      }
@@ -54,7 +55,7 @@
              return toEquip;
          } else {
              return ItemStack.EMPTY;
-@@ -780,38 +_,147 @@
+@@ -780,38 +_,187 @@
          return true;
      }
  
@@ -81,8 +82,12 @@
 +     * returns false for any given distance, and this method returns true if {@link #removeWhenFarAway(double)}
 +     * may currently return true or false.
 +     */
-+    public boolean gale$canRemoveWhenFarAway() {
++    public boolean gale$canRemoveWhenFarAway() { // Gale - Event-driven - Mob.checkDespawnPlayerTrackingMode - TODO Watch for changes in return value
 +        return this.removeWhenFarAway(-1);
++    }
++
++    public void gale$eventDriven_canRemoveWhenFarAway_postUpdate() {
++        this.gale$eventDriven_checkDespawnPlayerTrackingMode_update(); // Gale - Event-driven - Mob.checkDespawnPlayerTrackingMode
 +    }
 +
 +    public boolean gale$eventDriven_requiresCustomPersistence_compute() { // Gale - Event-driven - Mob.requiresCustomPersistence
@@ -136,10 +141,14 @@
 +    // Gale end - Event-driven - Mob.shouldDespawnInPeaceful
 +
 +    // Gale start - Event-driven - Mob.mustDespawnBecauseOfPeacefulDifficulty
-+    protected boolean gale$eventDriven_mustDespawnBecauseOfPeacefulDifficulty;
++    protected boolean gale$eventDriven_mustDespawnBecauseOfPeacefulDifficulty; // Gale - Event-driven - Mob.checkDespawnPlayerTrackingMode - TODO Watch for new writes
 +
 +    public void gale$eventDriven_mustDespawnBecauseOfPeacefulDifficulty_update() {
-+        this.gale$eventDriven_mustDespawnBecauseOfPeacefulDifficulty = this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful();
++        boolean newValue = this.level().getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful();
++        if (this.gale$eventDriven_mustDespawnBecauseOfPeacefulDifficulty != newValue) {
++            this.gale$eventDriven_mustDespawnBecauseOfPeacefulDifficulty = newValue;
++            this.gale$eventDriven_checkDespawnPlayerTrackingMode_update(); // Gale - Event-driven - Mob.checkDespawnPlayerTrackingMode
++        }
 +    }
 +
 +    @Override
@@ -169,12 +178,43 @@
 +    // Gale end - Event-driven - Mob.isLeashed
 +
 +    // Gale start - Event-driven - Mob.isPersistent
-+    public boolean gale$eventDriven_isPersistent;
++    public boolean gale$eventDriven_isPersistent; // Gale - Event-driven - Mob.checkDespawnPlayerTrackingMode - TODO Watch for new writes
 +
 +    public void gale$eventDriven_isPersistent_update() {
-+        this.gale$eventDriven_isPersistent = this.persistenceRequired || this.gale$eventDriven_requiresCustomPersistence;
++        boolean newValue = this.persistenceRequired || this.gale$eventDriven_requiresCustomPersistence;
++        if (this.gale$eventDriven_isPersistent != newValue) {
++            this.gale$eventDriven_isPersistent = newValue;
++            this.gale$eventDriven_checkDespawnPlayerTrackingMode_update(); // Gale - Event-driven - Mob.checkDespawnPlayerTrackingMode
++        }
 +    }
 +    // Gale end - Event-driven - Mob.isPersistent
++
++    // Gale start - Optimize Mob.checkDespawn
++    /**
++     * Whether this mob needs to track players for {@link #checkDespawn}:
++     * <ul>
++     *     <li>0 = none</li>
++     *     <li>1 = only for the {@link io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRangePair#soft()} distance</li>
++     *     <li>2 = for both {@link io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRangePair#soft()} and
++     *     {@link io.papermc.paper.configuration.WorldConfiguration.Entities.Spawning.DespawnRangePair#hard()} distances</li>
++     * </ul>
++     */
++    public int gale$eventDriven_checkDespawnPlayerTrackingMode;
++
++    public void gale$eventDriven_checkDespawnPlayerTrackingMode_update() {
++        this.gale$eventDriven_checkDespawnPlayerTrackingMode = this.gale$eventDriven_checkDespawnPlayerTrackingMode_compute();
++    }
++
++    private byte gale$eventDriven_checkDespawnPlayerTrackingMode_compute() {
++        if (this.gale$eventDriven_mustDespawnBecauseOfPeacefulDifficulty || this.gale$eventDriven_isPersistent || this.level().gale$eventDriven_affectsSpawningSelectorPlayerCount == 0) {
++            return 0;
++        } else if (!this.gale$canRemoveWhenFarAway()) {
++            return 1;
++        } else {
++            return 2;
++        }
++    }
++    // Gale end - Optimize Mob.checkDespawn
 +
      @Override
      public void checkDespawn() {
@@ -201,14 +241,15 @@
                  final double distanceSquared = dxSqr + dzSqr + dySqr;
                  // Despawn if hard/soft limit is exceeded
 -                if (despawnRangePair.hard().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy) && this.removeWhenFarAway(distanceSquared)) {
-+                if (this.gale$canRemoveWhenFarAway() && despawnRangePair.hard().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy) && this.removeWhenFarAway(distanceSquared)) { // Gale - Optimize Mob.checkDespawn
++                boolean canRemoveWhenFarAway = this.gale$canRemoveWhenFarAway(); // Gale - Optimize Mob.checkDespawn
++                if (canRemoveWhenFarAway && despawnRangePair.hard().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy) && this.removeWhenFarAway(distanceSquared)) { // Gale - Optimize Mob.checkDespawn
                      this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
                  }
  
 -                if (despawnRangePair.soft().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy)) {
 -                    if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(distanceSquared)) {
 +                if (despawnRangePair.soft().shouldDespawn(shape, dxSqr, dySqr, dzSqr, dy)) { // Gale - Optimize Mob.checkDespawn
-+                    if (this.gale$canRemoveWhenFarAway() && this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(distanceSquared)) {
++                    if (canRemoveWhenFarAway && this.noActionTime > 600 && this.random.nextInt(800) == 0 && this.removeWhenFarAway(distanceSquared)) {
                          this.discard(EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
                      }
                  } else {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/axolotl/Axolotl.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/axolotl/Axolotl.java.patch
@@ -40,7 +40,7 @@
      }
  
      @Override
-@@ -552,6 +_,24 @@
+@@ -552,6 +_,28 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
@@ -51,7 +51,11 @@
 +    private boolean gale$eventDriven_canRemoveWhenFarAway;
 +
 +    public void gale$eventDriven_canRemoveWhenFarAway_update() {
-+        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        boolean newValue = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        if (this.gale$eventDriven_canRemoveWhenFarAway != newValue) {
++            this.gale$eventDriven_canRemoveWhenFarAway = newValue;
++            this.gale$eventDriven_canRemoveWhenFarAway_postUpdate();
++        }
 +    }
 +
 +    @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/chicken/Chicken.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/chicken/Chicken.java.patch
@@ -23,7 +23,7 @@
          input.getInt("EggLayTime").ifPresent(time -> this.eggTime = time);
          VariantUtils.readVariant(input, Registries.CHICKEN_VARIANT).ifPresent(this::setVariant);
          input.read("sound_variant", ResourceKey.codec(Registries.CHICKEN_SOUND_VARIANT))
-@@ -274,6 +_,18 @@
+@@ -274,6 +_,22 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
@@ -34,7 +34,11 @@
 +    private boolean gale$eventDriven_canRemoveWhenFarAway;
 +
 +    public void gale$eventDriven_canRemoveWhenFarAway_update() {
-+        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        boolean newValue = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        if (this.gale$eventDriven_canRemoveWhenFarAway != newValue) {
++            this.gale$eventDriven_canRemoveWhenFarAway = newValue;
++            this.gale$eventDriven_canRemoveWhenFarAway_postUpdate();
++        }
 +    }
 +
 +    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Cat.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Cat.java.patch
@@ -8,7 +8,7 @@
      }
  
      @Override
-@@ -467,12 +_,34 @@
+@@ -467,12 +_,38 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
@@ -20,7 +20,11 @@
 +    private boolean gale$eventDriven_canRemoveWhenFarAway;
 +
 +    public void gale$eventDriven_canRemoveWhenFarAway_update() {
-+        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        boolean newValue = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        if (this.gale$eventDriven_canRemoveWhenFarAway != newValue) {
++            this.gale$eventDriven_canRemoveWhenFarAway = newValue;
++            this.gale$eventDriven_canRemoveWhenFarAway_postUpdate();
++        }
 +    }
 +
 +    @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
@@ -25,7 +25,7 @@
          this.reassessTrustingGoals();
      }
  
-@@ -136,7 +_,44 @@
+@@ -136,7 +_,48 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
@@ -37,7 +37,11 @@
 +    private boolean gale$eventDriven_canRemoveWhenFarAway;
 +
 +    public void gale$eventDriven_canRemoveWhenFarAway_update() {
-+        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        boolean newValue = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        if (this.gale$eventDriven_canRemoveWhenFarAway != newValue) {
++            this.gale$eventDriven_canRemoveWhenFarAway = newValue;
++            this.gale$eventDriven_canRemoveWhenFarAway_postUpdate();
++        }
 +    }
 +
 +    @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/fish/AbstractFish.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/fish/AbstractFish.java.patch
@@ -16,7 +16,7 @@
      }
  
      public static AttributeSupplier.Builder createAttributes() {
-@@ -46,12 +_,32 @@
+@@ -46,12 +_,36 @@
      }
  
      @Override
@@ -37,7 +37,11 @@
 +    private boolean gale$eventDriven_canRemoveWhenFarAway;
 +
 +    public void gale$eventDriven_canRemoveWhenFarAway_update() {
-+        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        boolean newValue = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        if (this.gale$eventDriven_canRemoveWhenFarAway != newValue) {
++            this.gale$eventDriven_canRemoveWhenFarAway = newValue;
++            this.gale$eventDriven_canRemoveWhenFarAway_postUpdate();
++        }
 +    }
 +
 +    @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
@@ -8,7 +8,7 @@
      }
  
      @Override
-@@ -207,6 +_,24 @@
+@@ -207,6 +_,28 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
@@ -19,7 +19,11 @@
 +    private boolean gale$eventDriven_canRemoveWhenFarAway;
 +
 +    public void gale$eventDriven_canRemoveWhenFarAway_update() {
-+        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        boolean newValue = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        if (this.gale$eventDriven_canRemoveWhenFarAway != newValue) {
++            this.gale$eventDriven_canRemoveWhenFarAway = newValue;
++            this.gale$eventDriven_canRemoveWhenFarAway_postUpdate();
++        }
 +    }
 +
 +    @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/zombie/ZombieVillager.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/monster/zombie/ZombieVillager.java.patch
@@ -33,7 +33,7 @@
      }
  
      @Override
-@@ -188,6 +_,18 @@
+@@ -188,6 +_,22 @@
  
      @Override
      public boolean removeWhenFarAway(final double distSqr) {
@@ -44,7 +44,11 @@
 +    private boolean gale$eventDriven_canRemoveWhenFarAway;
 +
 +    public void gale$eventDriven_canRemoveWhenFarAway_update() {
-+        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        boolean newValue = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        if (this.gale$eventDriven_canRemoveWhenFarAway != newValue) {
++            this.gale$eventDriven_canRemoveWhenFarAway = newValue;
++            this.gale$eventDriven_canRemoveWhenFarAway_postUpdate();
++        }
 +    }
 +
 +    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raider.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/raid/Raider.java.patch
@@ -35,7 +35,7 @@
                  if (this.raid != null) {
                      this.raid.addWaveMob(level, this.wave, this, false);
                      if (this.isPatrolLeader()) {
-@@ -242,9 +_,28 @@
+@@ -242,9 +_,32 @@
          return this.getCurrentRaid() == null && super.removeWhenFarAway(distSqr);
      }
  
@@ -51,7 +51,11 @@
 +    private boolean gale$eventDriven_canRemoveWhenFarAway;
 +
 +    public void gale$eventDriven_canRemoveWhenFarAway_update() {
-+        this.gale$eventDriven_canRemoveWhenFarAway = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        boolean newValue = this.gale$eventDriven_canRemoveWhenFarAway_compute();
++        if (this.gale$eventDriven_canRemoveWhenFarAway != newValue) {
++            this.gale$eventDriven_canRemoveWhenFarAway = newValue;
++            this.gale$eventDriven_canRemoveWhenFarAway_postUpdate();
++        }
 +    }
 +
 +    private boolean gale$eventDriven_canRemoveWhenFarAway_compute() {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -8,19 +8,31 @@
  
      public static @Nullable BlockPos lastPhysicsProblem; // Spigot
      public final Map<ServerExplosion.CacheKey, Float> explosionDensityCache = new java.util.HashMap<>(); // Paper - Optimize explosions
-@@ -238,6 +_,18 @@
+@@ -238,6 +_,30 @@
          return ret;
      }
  
 +    // Gale start - Event-driven - Level.affectsSpawningSelectorPlayerCount
-+    public int gale$eventDriven_affectsSpawningSelectorPlayerCount;
++    public int gale$eventDriven_affectsSpawningSelectorPlayerCount; // Gale - Event-driven - Mob.checkDespawnPlayerTrackingMode - TODO Watch for new writes
 +
 +    public void gale$eventDriven_affectsSpawningSelectorPlayerCount_increment() {
-+        this.gale$eventDriven_affectsSpawningSelectorPlayerCount++;
++        if (this.gale$eventDriven_affectsSpawningSelectorPlayerCount++ == 0) {
++            // Gale start - Event-driven - Mob.checkDespawnPlayerTrackingMode
++            for (Entity entity : this.getEntities().getAll()) {
++                if (entity instanceof net.minecraft.world.entity.Mob mob) mob.gale$eventDriven_checkDespawnPlayerTrackingMode_update();
++            }
++            // Gale end - Event-driven - Mob.checkDespawnPlayerTrackingMode
++        }
 +    }
 +
 +    public void gale$eventDriven_affectsSpawningSelectorPlayerCount_decrement() {
-+        this.gale$eventDriven_affectsSpawningSelectorPlayerCount--;
++        if (--this.gale$eventDriven_affectsSpawningSelectorPlayerCount == 0) {
++            // Gale start - Event-driven - Mob.checkDespawnPlayerTrackingMode
++            for (Entity entity : this.getEntities().getAll()) {
++                if (entity instanceof net.minecraft.world.entity.Mob mob) mob.gale$eventDriven_checkDespawnPlayerTrackingMode_update();
++            }
++            // Gale end - Event-driven - Mob.checkDespawnPlayerTrackingMode
++        }
 +    }
 +    // Gale end - Event-driven - Level.affectsSpawningSelectorPlayerCount
 +


### PR DESCRIPTION
This is to prepare for more future optimizations of `Mob.checkDespawn`.