### PR TITLE
Do less work - ItemLore.styledLines (computed only when used)

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/ai/village/poi/PoiTypes.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/ai/village/poi/PoiTypes.java.patch
@@ -28,7 +28,7 @@
 +        return Optional.ofNullable(gale$forStateNullable(state));
 +    }
 +
-+    public static @org.jetbrains.annotations.Nullable Holder<PoiType> gale$forStateNullable(final BlockState state) {
++    public static @org.jspecify.annotations.Nullable Holder<PoiType> gale$forStateNullable(final BlockState state) {
 +        return state.gale$precompute_poiType; // Gale - Pre-compute - PoiTypes.forState()
 +        // Gale end - Do less work - PoiTypes.forState() (skip Optional creation)
      }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/item/component/ItemLore.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/item/component/ItemLore.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/item/component/ItemLore.java
++++ b/net/minecraft/world/item/component/ItemLore.java
+@@ -46,4 +_,11 @@
+     ) {
+         this.styledLines.forEach(consumer);
+     }
++
++    // Gale start - Local code optimization - ItemLore.equals()
++    @Override
++    public boolean equals(Object obj) {
++        return this == obj || obj instanceof net.minecraft.world.item.component.ItemLore other && lines.size() == other.lines.size() && lines.equals(other.lines) && styledLines.equals(other.styledLines);
++    }
++    // Gale end - Local code optimization - ItemLore.equals()
+ }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/item/component/ItemLore.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/item/component/ItemLore.java.patch
@@ -1,14 +1,80 @@
 --- a/net/minecraft/world/item/component/ItemLore.java
 +++ b/net/minecraft/world/item/component/ItemLore.java
-@@ -46,4 +_,11 @@
-     ) {
-         this.styledLines.forEach(consumer);
-     }
+@@ -17,7 +_,37 @@
+ import net.minecraft.world.item.Item;
+ import net.minecraft.world.item.TooltipFlag;
+ 
+-public record ItemLore(List<Component> lines, List<Component> styledLines) implements TooltipProvider {
++// Gale start - Do less work - ItemLore.styledLines (computed only when used)
++public final class ItemLore implements TooltipProvider {
++    private final List<Component> lines;
++    private @org.jspecify.annotations.Nullable List<Component> styledLines;
++    public ItemLore(List<Component> lines, List<Component> styledLines) {
++        this.lines = lines;
++        this.styledLines = styledLines;
++        if (lines.size() > 256) {
++            throw new IllegalArgumentException("Got " + lines.size() + " lines, but maximum is 256");
++        }
++    }
++    public List<Component> lines() { return this.lines; }
++    public List<Component> styledLines() {
++        if (this.styledLines == null) {
++            this.styledLines = Lists.transform(lines, component -> ComponentUtils.mergeStyles(component, LORE_STYLE));
++        }
++        return this.styledLines;
++    }
 +
-+    // Gale start - Local code optimization - ItemLore.equals()
++    private int gale$cached_hashCode; // Gale - Cache - ItemLore.hashCode()
++
++    @Override
++    public int hashCode() {
++        int hashCode = this.gale$cached_hashCode;
++        if (hashCode == 0) {
++            hashCode = 1 + this.lines.hashCode();
++            this.gale$cached_hashCode = hashCode;
++        }
++        return hashCode;
++    }
++    // Gale end - Do less work - ItemLore.styledLines (computed only when used)
+     public static final ItemLore EMPTY = new ItemLore(List.of());
+     public static final int MAX_LINES = 256;
+     private static final Style LORE_STYLE = Style.EMPTY.withColor(ChatFormatting.DARK_PURPLE).withItalic(true);
+@@ -27,14 +_,16 @@
+         .map(ItemLore::new, ItemLore::lines);
+ 
+     public ItemLore(final List<Component> lines) {
+-        this(lines, Lists.transform(lines, component -> ComponentUtils.mergeStyles(component, LORE_STYLE)));
++        this(lines, null); // Gale - Do less work - ItemLore.styledLines (computed only when used)
+     }
+ 
+-    public ItemLore {
+-        if (lines.size() > 256) {
+-            throw new IllegalArgumentException("Got " + lines.size() + " lines, but maximum is 256");
+-        }
+-    }
++    // Gale start - Do less work - ItemLore.styledLines (computed only when used)
++    // public ItemLore {
++    //     if (lines.size() > 256) {
++    //         throw new IllegalArgumentException("Got " + lines.size() + " lines, but maximum is 256");
++    //     }
++    // }
++    // Gale end - Do less work - ItemLore.styledLines (computed only when used)
+ 
+     public ItemLore withLineAdded(final Component component) {
+         return new ItemLore(Util.copyAndAdd(this.lines, component));
+@@ -44,6 +_,13 @@
+     public void addToTooltip(
+         final Item.TooltipContext context, final Consumer<Component> consumer, final TooltipFlag flag, final DataComponentGetter components
+     ) {
+-        this.styledLines.forEach(consumer);
+-    }
++        this.styledLines().forEach(consumer); // Gale - Do less work - ItemLore.styledLines (computed only when used)
++    }
++
++    // Gale start - Faster implementation for subclass - ItemLore.equals() (skip styledLines)
 +    @Override
 +    public boolean equals(Object obj) {
-+        return this == obj || obj instanceof net.minecraft.world.item.component.ItemLore other && lines.size() == other.lines.size() && lines.equals(other.lines) && styledLines.equals(other.styledLines);
++        return this == obj || obj instanceof net.minecraft.world.item.component.ItemLore other && this.lines.equals(other.lines);
 +    }
-+    // Gale end - Local code optimization - ItemLore.equals()
++    // Gale end - Faster implementation for subclass - ItemLore.equals() (skip styledLines)
  }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/biome/BiomeManager.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/biome/BiomeManager.java.patch
@@ -5,9 +5,9 @@
      private final BiomeManager.NoiseBiomeSource noiseBiomeSource;
      private final long biomeZoomSeed;
 +    // Gale start - Cache - BiomeManager.getBiome()
-+    private final long @org.jetbrains.annotations.Nullable [] biomeCacheKeys;
-+    private final int @org.jetbrains.annotations.Nullable [] biomeCacheVersions;
-+    private final Holder<Biome> @org.jetbrains.annotations.Nullable [] biomeCacheValues;
++    private final long @org.jspecify.annotations.Nullable [] biomeCacheKeys;
++    private final int @org.jspecify.annotations.Nullable [] biomeCacheVersions;
++    private final Holder<Biome> @org.jspecify.annotations.Nullable [] biomeCacheValues;
 +    private int cacheVersion;
 +    // Gale end - Cache - BiomeManager.getBiome()
  


### PR DESCRIPTION
## Motivation
Try to reduce the expensive `ComponentUtils.mergeStyles` in the ItemLore constructor, no need to call `ComponentUtils.mergeStyles` every time if the component list is completely different.

The `styledLines` just convert from `lines` via `ComponentUtils.mergeStyles`, so `lines` and `styledLines` should have the same size; only one size comparison is needed here.

It's equivalent to the original equals, so I think there's no need to override `hashCode()` too. Unless we need to convert the record to the normal class and cache the hash code here. 

## Changes
Overridden `equals()` in `ItemLore .class` to compare component list size of `lines` first, and return earlier.

## Context
Was AI used to write this pull request: No
