### PR TITLE
Optimization Entity#setBoundingBox

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -193,6 +193,7 @@
      }
  
      public final void setBoundingBox(final AABB bb) {
++        // Gale start - Do less work - Skip unnecessary Entity.move() code if bounding box and position are unchanged
 +        if (!this.boundingBoxChanged) {
 +            AABB current = this.bb;
 +            if (current != bb && (
@@ -205,6 +206,7 @@
 +                this.boundingBoxChanged = true;
 +            }
 +        }
++        // Gale end - Do less work - Skip unnecessary Entity.move() code if bounding box and position are unchangedgit status
          // CraftBukkit start - block invalid bounding boxes
          double minX = bb.minX,
                  minY = bb.minY,

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -189,15 +189,22 @@
              Entity.RemovalReason removalReason = this.getRemovalReason();
              if (removalReason == null || removalReason.shouldDestroy()) {
                  this.level().gameEvent(this, GameEvent.ENTITY_DISMOUNT, oldVehicle.position);
-@@ -4580,6 +_,11 @@
+@@ -4580,6 +_,18 @@
      }
  
      public final void setBoundingBox(final AABB bb) {
-+        // Gale start - Do less work - Skip unnecessary Entity.move() code if bounding box and position are unchanged
-+        if (!this.bb.equals(bb)) {
-+            this.boundingBoxChanged = true;
++        if (!this.boundingBoxChanged) {
++            AABB current = this.bb;
++            if (current != bb && (
++                    current.minX != bb.minX ||
++                    current.minY != bb.minY ||
++                    current.minZ != bb.minZ ||
++                    current.maxX != bb.maxX ||
++                    current.maxY != bb.maxY ||
++                    current.maxZ != bb.maxZ)) {
++                this.boundingBoxChanged = true;
++            }
 +        }
-+        // Gale end - Do less work - Skip unnecessary Entity.move() code if bounding box and position are unchanged
          // CraftBukkit start - block invalid bounding boxes
          double minX = bb.minX,
                  minY = bb.minY,


### PR DESCRIPTION
## Motivation
entity setboundingbox gets called every tick for every entity so even tiny overhead adds up quickly currently it calls aabb equals unconditionally triggering unnecessary instanceof checks and double compares when we already know the box changed we are wasting cpu cycles for nothing

## Changes
dded a skip check: if boundingBoxChanged is already true for the current tick, we stop right there and skip the rest of the comparison.

Replaced AABB.equals() with manual field comparisons using !=. This gets rid of all that unnecessary instanceof and cast overhead.

Added a simple reference equality check to handle the common case where the same AABB instance is passed in.

## Context
No
