### PR TITLE
Optimization delta zero-check in Entity#move

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -92,7 +92,7 @@
              // Paper end
 -
 +            // Gale start - Do less work - Skip unnecessary Entity.move() code if bounding box and position are unchanged
-+            if (!this.boundingBoxChanged && delta.equals(Vec3.ZERO)) {
++            if (!this.boundingBoxChanged && delta.x == 0.0D && delta.y == 0.0D && delta.z == 0.0D) {
 +                this.horizontalCollision = false;
 +                this.verticalCollision = false;
 +                this.verticalCollisionBelow = false;


### PR DESCRIPTION
## Motivation
every single tick for every entity entity move calls delta equals vec3 zero which just like the recently merged setboundingbox optimization involves instance of checks casting and three double compares this overhead scales heavily and destroys performance on servers with lots of entities

## Changes
replacied delta equals vec3 zero with direct field comparisons to skip all the instanceof and cast overhead doing the exact same thing but using way less cpu per call

## Context
no