### PR TITLE
Optimization Entity#setVehicle: iteration + fast path

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -164,23 +164,15 @@
 +        Entity oldVehicle = this.vehicle;
 +        if (oldVehicle == vehicle) return;
 +        int playerPassengerCount = this.gale$eventDriven_playerPassengerCount;
++        if (playerPassengerCount != 0) {
++            if (oldVehicle != null) {
++                oldVehicle.gale$eventDriven_playerPassengerCount_add(-playerPassengerCount);
++            }
++            if (vehicle != null) {
++                vehicle.gale$eventDriven_playerPassengerCount_add(playerPassengerCount);
++            }
++        }
 +        this.vehicle = vehicle;
-+        if (playerPassengerCount == 0) return;
-+        if (oldVehicle != null && vehicle != null && oldVehicle.vehicle == vehicle.vehicle) {
-+            oldVehicle.gale$eventDriven_playerPassengerCount -= playerPassengerCount;
-+            vehicle.gale$eventDriven_playerPassengerCount += playerPassengerCount;
-+            return;
-+        }
-+        Entity current = oldVehicle;
-+        while (current != null) {
-+            current.gale$eventDriven_playerPassengerCount -= playerPassengerCount;
-+            current = current.vehicle;
-+        }
-+        current = vehicle;
-+        while (current != null) {
-+            current.gale$eventDriven_playerPassengerCount += playerPassengerCount;
-+            current = current.vehicle;
-+        }
 +    }
 +
      protected boolean canRide(final Entity vehicle) {
@@ -245,9 +237,10 @@
 +    }
 +
 +    private void gale$eventDriven_playerPassengerCount_add(int delta) {
-+        this.gale$eventDriven_playerPassengerCount += delta;
-+        if (this.vehicle != null) {
-+            this.vehicle.gale$eventDriven_playerPassengerCount_add(delta);
++        Entity current = this;
++        while (current != null) {
++            current.gale$eventDriven_playerPassengerCount += delta;
++            current = current.vehicle;
 +        }
 +    }
 +

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -164,15 +164,23 @@
 +        Entity oldVehicle = this.vehicle;
 +        if (oldVehicle == vehicle) return;
 +        int playerPassengerCount = this.gale$eventDriven_playerPassengerCount;
-+        if (playerPassengerCount != 0) {
-+            if (oldVehicle != null) {
-+                oldVehicle.gale$eventDriven_playerPassengerCount_add(-playerPassengerCount);
-+            }
-+            if (vehicle != null) {
-+                vehicle.gale$eventDriven_playerPassengerCount_add(playerPassengerCount);
-+            }
-+        }
 +        this.vehicle = vehicle;
++        if (playerPassengerCount == 0) return;
++        if (oldVehicle != null && vehicle != null && oldVehicle.vehicle == vehicle.vehicle) {
++            oldVehicle.gale$eventDriven_playerPassengerCount -= playerPassengerCount;
++            vehicle.gale$eventDriven_playerPassengerCount += playerPassengerCount;
++            return;
++        }
++        Entity current = oldVehicle;
++        while (current != null) {
++            current.gale$eventDriven_playerPassengerCount -= playerPassengerCount;
++            current = current.vehicle;
++        }
++        current = vehicle;
++        while (current != null) {
++            current.gale$eventDriven_playerPassengerCount += playerPassengerCount;
++            current = current.vehicle;
++        }
 +    }
 +
      protected boolean canRide(final Entity vehicle) {


### PR DESCRIPTION
## Motivation
setvehicle currently uses recursion to update vehicle chains, which is inefficient and risks stack overflows on deep chains Also it unnecessarily traverses the entire chain even when vehicles share the same parent

## Changes
Replaced recursion with iterative loops for both setVehicle and add calls.

Added a fast path: if oldVehicle and vehicle share the same parent, we only update the immediate vehicles instead of walking the whole chain.

Updated this.vehicle assignment order to ensure state consistency during traversal.

## Context
no
