### PR TITLE
Use pattern matching in Level#checkEntityCollision to reduce casts

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -236,8 +236,8 @@
              }
  
 +            // Gale start - Do less work - Level.checkEntityCollision()
-+            if (checkCanSee && source instanceof net.minecraft.server.level.ServerPlayer && entity instanceof net.minecraft.server.level.ServerPlayer
-+                && !((net.minecraft.server.level.ServerPlayer) source).getBukkitEntity().canSee(((net.minecraft.server.level.ServerPlayer) entity).getBukkitEntity())) {
++            if (checkCanSee && source instanceof net.minecraft.server.level.ServerPlayer sourceServerPlayer && entity instanceof net.minecraft.server.level.ServerPlayer entityServerPlayer
++                && !sourceServerPlayer.getBukkitEntity().canSee(entityServerPlayer.getBukkitEntity())) {
 +                continue;
 +            }
 +            // Gale end - Do less work - Level.checkEntityCollision()


### PR DESCRIPTION
## Motivation
checkentitycollision runs every tick and performs multiple redundant casts to serverplayer when checking vanish status. casting is not free and doing it over and over in a hot path is just wasteful

## Changes
switched to java pattern matching for instanceof so we get the casted variable directly.

cut down on the repetitive casting logic entirely.

## Context
removes 4 unnecessary casts per iteration.

code is now cleaner and easier to read.

minor cpu savings but it adds up in heavy collision scenarios.