### PR TITLE
Fix startup crash from early block state cache initialization

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -1,8 +1,9 @@
 --- a/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -237,6 +_,10 @@
+@@ -237,6 +_,11 @@
          // Paper start - initialize global and world-defaults configuration
          this.paperConfigurations.initializeGlobalConfiguration(this.registryAccess());
++        net.minecraft.world.level.block.state.BlockBehaviour.gale$eventDriven_reload(); // Gale - Initialize config-dependent block-state caches
          this.paperConfigurations.initializeWorldDefaultsConfiguration(this.registryAccess());
 +        // Gale start - Configuration - Initialize configuration
 +        // this.galeConfigurations.initializeGlobalConfiguration(this.registryAccess()); // TODO Gale configuration temp disabled

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -29,14 +29,17 @@
  
          private static void initCaches(final VoxelShape shape, final boolean neighbours) {
              ((ca.spottedleaf.moonrise.patches.collisions.shape.CollisionVoxelShape)shape).moonrise$isFullBlock();
-@@ -623,6 +_,11 @@
+@@ -623,6 +_,14 @@
  
              this.propagatesSkylightDown = this.owner.propagatesSkylightDown(this.asState());
              this.lightDampening = this.owner.getLightDampening(this.asState());
 +            // Gale start - Pre-compute - BlockBehaviour.hasBlockEntity()
 +            this.gale$precompute_hasBlockEntity = this.getBlock() instanceof EntityBlock;
 +            // Gale end - Pre-compute - BlockBehaviour.hasBlockEntity()
-+            this.gale$eventDriven_isDestroyable_update(); // Gale - Event-driven - BlockBehaviour.isDestroyable()
++            // Paper configuration is initialized after block bootstrap.
++            if (io.papermc.paper.configuration.GlobalConfiguration.get() != null) {
++                this.gale$eventDriven_isDestroyable_update(); // Gale - Event-driven - BlockBehaviour.isDestroyable()
++            }
 +            this.gale$eventDriven_pistonPushReaction_update(); // Gale - Event-driven - BlockBehaviour.getPistonPushReaction()
              // Paper start - rewrite chunk system
              this.isConditionallyFullOpaque = this.canOcclude & this.useShapeForLightOcclusion;

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -36,10 +36,7 @@
 +            // Gale start - Pre-compute - BlockBehaviour.hasBlockEntity()
 +            this.gale$precompute_hasBlockEntity = this.getBlock() instanceof EntityBlock;
 +            // Gale end - Pre-compute - BlockBehaviour.hasBlockEntity()
-+            // Paper configuration is initialized after block bootstrap.
-+            if (io.papermc.paper.configuration.GlobalConfiguration.get() != null) {
-+                this.gale$eventDriven_isDestroyable_update(); // Gale - Event-driven - BlockBehaviour.isDestroyable()
-+            }
++            this.gale$eventDriven_isDestroyable_update(); // Gale - Event-driven - BlockBehaviour.isDestroyable()
 +            this.gale$eventDriven_pistonPushReaction_update(); // Gale - Event-driven - BlockBehaviour.getPistonPushReaction()
              // Paper start - rewrite chunk system
              this.isConditionallyFullOpaque = this.canOcclude & this.useShapeForLightOcclusion;
@@ -72,6 +69,8 @@
 +        }
 +
 +        private void gale$eventDriven_isDestroyable_update() {
++            // Paper configuration is initialized after block bootstrap.
++            if (io.papermc.paper.configuration.GlobalConfiguration.get() == null) return;
 +            boolean newValue = this.getBlock().isDestroyable();
 +            if (this.gale$eventDriven_isDestroyable != newValue) {
 +                this.gale$eventDriven_isDestroyable = newValue;


### PR DESCRIPTION
Gale initialized the cached #isDestroyable value during block bootstrap while paper's global configuration was still null, this PR simply fixes that NPE
