### PR TITLE
optimize structure placement during biome decoration

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
@@ -24,10 +24,7 @@
 -                                    .forEach(start -> start.placeInChunk(level, structureManager, this, random, getWritableArea(chunk), centerPos));
 +                                // Gale start - Reuse structure decoration data
 +                                structureStarts.clear();
-+                                LongSet references = chunk.getReferencesForStructure(structure);
-+                                if (!references.isEmpty()) {
-+                                    structureManager.fillStartsForStructure(structure, references, structureStarts::add);
-+                                }
++                                structureManager.fillStartsForStructure(structure, chunk.getReferencesForStructure(structure), structureStarts::add);
 +                                for (StructureStart start : structureStarts) {
 +                                    start.placeInChunk(level, structureManager, this, random, getWritableArea(chunk), centerPos);
 +                                }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
@@ -6,13 +6,13 @@
                  int generationSteps = Math.max(GenerationStep.Decoration.values().length, featureStepCount);
 +                // Gale start - Reuse structure decoration data
 +                boolean generateStructures = structureManager.shouldGenerateStructures();
-+                @Nullable List<StructureStart> structureStarts = generateStructures ? new ArrayList<>() : null;
++                it.unimi.dsi.fastutil.objects.@Nullable ObjectArrayList<StructureStart> structureStarts = generateStructures ? new it.unimi.dsi.fastutil.objects.ObjectArrayList<>() : null;
 +                // Gale end - Reuse structure decoration data
  
                  for (int stepIndex = 0; stepIndex < generationSteps; stepIndex++) {
                      int index = 0;
 -                    if (structureManager.shouldGenerateStructures()) {
-+                    if (generateStructures) {
++                    if (generateStructures) { // Gale - Reuse structure decoration data
                          for (Structure structure : structuresByStep.getOrDefault(stepIndex, Collections.emptyList())) {
                              random.setFeatureSeed(decorationSeed, index, stepIndex);
                              Supplier<String> currentlyGenerating = () -> structuresRegistry.getResourceKey(structure)
@@ -25,8 +25,9 @@
 +                                // Gale start - Reuse structure decoration data
 +                                structureStarts.clear();
 +                                structureManager.fillStartsForStructure(structure, chunk.getReferencesForStructure(structure), structureStarts::add);
-+                                for (StructureStart start : structureStarts) {
-+                                    start.placeInChunk(level, structureManager, this, random, getWritableArea(chunk), centerPos);
++                                Object[] structureStartsArray = structureStarts.elements();
++                                for (int structureStartIndex = 0, structureStartsSize = structureStarts.size(); structureStartIndex < structureStartsSize; structureStartIndex++) {
++                                    ((StructureStart) structureStartsArray[structureStartIndex]).placeInChunk(level, structureManager, this, random, getWritableArea(chunk), centerPos);
 +                                }
 +                                // Gale end - Reuse structure decoration data
                              } catch (Exception e) {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/chunk/ChunkGenerator.java.patch
@@ -1,0 +1,37 @@
+--- a/net/minecraft/world/level/chunk/ChunkGenerator.java
++++ b/net/minecraft/world/level/chunk/ChunkGenerator.java
+@@ -363,10 +_,14 @@
+             try {
+                 Registry<PlacedFeature> featureRegistry = level.registryAccess().lookupOrThrow(Registries.PLACED_FEATURE);
+                 int generationSteps = Math.max(GenerationStep.Decoration.values().length, featureStepCount);
++                // Gale start - Reuse structure decoration data
++                boolean generateStructures = structureManager.shouldGenerateStructures();
++                @Nullable List<StructureStart> structureStarts = generateStructures ? new ArrayList<>() : null;
++                // Gale end - Reuse structure decoration data
+ 
+                 for (int stepIndex = 0; stepIndex < generationSteps; stepIndex++) {
+                     int index = 0;
+-                    if (structureManager.shouldGenerateStructures()) {
++                    if (generateStructures) {
+                         for (Structure structure : structuresByStep.getOrDefault(stepIndex, Collections.emptyList())) {
+                             random.setFeatureSeed(decorationSeed, index, stepIndex);
+                             Supplier<String> currentlyGenerating = () -> structuresRegistry.getResourceKey(structure)
+@@ -375,8 +_,16 @@
+ 
+                             try {
+                                 level.setCurrentlyGenerating(currentlyGenerating);
+-                                structureManager.startsForStructure(sectionPos, structure)
+-                                    .forEach(start -> start.placeInChunk(level, structureManager, this, random, getWritableArea(chunk), centerPos));
++                                // Gale start - Reuse structure decoration data
++                                structureStarts.clear();
++                                LongSet references = chunk.getReferencesForStructure(structure);
++                                if (!references.isEmpty()) {
++                                    structureManager.fillStartsForStructure(structure, references, structureStarts::add);
++                                }
++                                for (StructureStart start : structureStarts) {
++                                    start.placeInChunk(level, structureManager, this, random, getWritableArea(chunk), centerPos);
++                                }
++                                // Gale end - Reuse structure decoration data
+                             } catch (Exception e) {
+                                 CrashReport report = CrashReport.forThrowable(e, "Feature placement");
+                                 report.addCategory("Feature").setDetail("Description", currentlyGenerating::get);


### PR DESCRIPTION
This patch simply making structure placement during biome decoration more efficient by reusing data already available for the current chunk instead of repeatedly looking it up and creating temporary objects. It also avoids repeating the same structure generation check for every decoration step ^^

