### PR TITLE
Optimize ActivationRange bounding box lookup

### DIFF
--- a/gale-server/minecraft-patches/sources/io/papermc/paper/entity/activation/ActivationRange.java.patch
+++ b/gale-server/minecraft-patches/sources/io/papermc/paper/entity/activation/ActivationRange.java.patch
@@ -8,3 +8,27 @@
          final int miscActivationRange = world.spigotConfig.miscActivationRange;
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
+@@ -149,14 +150,15 @@
+             }
+ 
+             final int worldHeight = world.getHeight();
+-            ActivationRange.maxBB = player.getBoundingBox().inflate(maxRange, worldHeight, maxRange);
+-            ActivationType.MISC.boundingBox = player.getBoundingBox().inflate(miscActivationRange, worldHeight, miscActivationRange);
+-            ActivationType.RAIDER.boundingBox = player.getBoundingBox().inflate(raiderActivationRange, worldHeight, raiderActivationRange);
+-            ActivationType.ANIMAL.boundingBox = player.getBoundingBox().inflate(animalActivationRange, worldHeight, animalActivationRange);
+-            ActivationType.MONSTER.boundingBox = player.getBoundingBox().inflate(monsterActivationRange, worldHeight, monsterActivationRange);
+-            ActivationType.WATER.boundingBox = player.getBoundingBox().inflate(waterActivationRange, worldHeight, waterActivationRange);
+-            ActivationType.FLYING_MONSTER.boundingBox = player.getBoundingBox().inflate(flyingActivationRange, worldHeight, flyingActivationRange);
+-            ActivationType.VILLAGER.boundingBox = player.getBoundingBox().inflate(villagerActivationRange, worldHeight, villagerActivationRange);
++            final AABB playerBB = player.getBoundingBox(); // Gale start - hoist player bounding box lookup
++            ActivationRange.maxBB = playerBB.inflate(maxRange, worldHeight, maxRange);
++            ActivationType.MISC.boundingBox = playerBB.inflate(miscActivationRange, worldHeight, miscActivationRange);
++            ActivationType.RAIDER.boundingBox = playerBB.inflate(raiderActivationRange, worldHeight, raiderActivationRange);
++            ActivationType.ANIMAL.boundingBox = playerBB.inflate(animalActivationRange, worldHeight, animalActivationRange);
++            ActivationType.MONSTER.boundingBox = playerBB.inflate(monsterActivationRange, worldHeight, monsterActivationRange);
++            ActivationType.WATER.boundingBox = playerBB.inflate(waterActivationRange, worldHeight, waterActivationRange);
++            ActivationType.FLYING_MONSTER.boundingBox = playerBB.inflate(flyingActivationRange, worldHeight, flyingActivationRange);
++            ActivationType.VILLAGER.boundingBox = playerBB.inflate(villagerActivationRange, worldHeight, villagerActivationRange); // Gale end - hoist player bounding box lookup
+ 
+             final List<Entity> entities = world.getEntities((Entity) null, ActivationRange.maxBB, e -> true);
+             final boolean tickMarkers = world.paperConfig().entities.markers.tick;


### PR DESCRIPTION
Motivation
I noticed that inside the ActivationRange#activateEntities loop, player.getBoundingBox() is called 8 times in a row for every single player. Since the bounding box doesn't change during those calls, that's a lot of redundant virtual method calls happening every tick. On servers with a high player count, this adds up quickly, so I wanted to clean it up.

Changes
Cached player.getBoundingBox() into a local AABB playerBB variable so it's only called once per player.

Updated the 8 inflate(...) calls to just reuse that cached playerBB.

There is zero behavior change here—it's the exact same logic, just less redundant work for the CPU.

Context
Regarding the AI usage: yes, I did use it for this one. I actually wrote the change by hand initially, but I kept hitting a "Patch engine failure" because of a weird UTF-8 BOM issue in the patch file. I ended up letting AI handle the flow (editing the source and rebuilding the patch) to fix the encoding mess, and it generated a clean patch that finally applied correctly. The optimization concept and the code logic itself are still my own.