### PR TITLE
Optimize ItemEntity mergeWithNeighbours

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/item/ItemEntity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/item/ItemEntity.java.patch
@@ -1,0 +1,27 @@
+--- a/net/minecraft/world/entity/item/ItemEntity.java
++++ b/net/minecraft/world/entity/item/ItemEntity.java
+@@ -255,13 +_,19 @@
+ 
+     private void mergeWithNeighbours() {
+         if (this.isMergable()) {
+-            double radius = this.level().spigotConfig.itemMerge; // Spigot
+-            for (ItemEntity entity : this.level()
+-                .getEntitiesOfClass(ItemEntity.class, this.getBoundingBox().inflate(radius, this.level().paperConfig().entities.behavior.onlyMergeItemsHorizontally ? 0 : radius - 0.5D, radius), other -> other != this && other.isMergable())) { // Spigot // Paper - configuration to only merge items horizontally
++            // Gale start - hoist level and config lookups
++            final Level level = this.level();
++            final io.papermc.paper.configuration.WorldConfiguration paperConfig = level.paperConfig();
++            final double radius = level.spigotConfig.itemMerge;
++            final double yInflate = paperConfig.entities.behavior.onlyMergeItemsHorizontally ? 0 : radius - 0.5D;
++            final boolean fixMergingThroughWalls = paperConfig.fixes.fixItemsMergingThroughWalls;
++            // Gale end - hoist level and config lookups
++            for (ItemEntity entity : level
++                .getEntitiesOfClass(ItemEntity.class, this.getBoundingBox().inflate(radius, yInflate, radius), other -> other != this && other.isMergable())) {
+                 if (entity.isMergable()) {
+                     // Paper start - Fix items merging through walls
+-                    if (this.level().paperConfig().fixes.fixItemsMergingThroughWalls) {
+-                        if (this.level().clipDirect(this.position(), entity.position(),
++                    if (fixMergingThroughWalls) {
++                        if (level.clipDirect(this.position(), entity.position(),
+                             net.minecraft.world.phys.shapes.CollisionContext.of(this)) == net.minecraft.world.phys.HitResult.Type.BLOCK) {
+                             continue;
+                         }


### PR DESCRIPTION
## Motivation

`ItemEntity#mergeWithNeighbours` runs on every ground item's tick loop (every 2 ticks when moving, every 40 when stationary). On servers with item farms, hundreds of item entities can invoke this method per second.

Inside the method, `this.level()` was being called 5 times and `paperConfig()` chain was walked twice per invocation, even though the returned values don't change during the call. On chunks with lots of dropped items, this adds up to a lot of redundant virtual calls and field dereferences.

## Changes

Hoisted the following out of the method body into local variables (computed once per call):

- `this.level()` → `final Level level`
- `level.paperConfig()` → `final WorldConfiguration paperConfig`
- `paperConfig.entities.behavior.onlyMergeItemsHorizontally ? 0 : radius - 0.5D` → `final double yInflate`
- `paperConfig.fixes.fixItemsMergingThroughWalls` → `final boolean fixMergingThroughWalls`

The `getEntitiesOfClass` call and `clipDirect` call inside the loop now use the cached `level` variable, and the wall-fix branch uses the cached boolean.

No behavior change — same values, just fewer lookups.