### PR TITLE
Optimize CompoundTag write to avoid double map lookup

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/nbt/CompoundTag.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/nbt/CompoundTag.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/nbt/CompoundTag.java
++++ b/net/minecraft/nbt/CompoundTag.java
+@@ -170,10 +_,11 @@
+ 
+     @Override
+     public void write(final DataOutput output) throws IOException {
+-        for (String key : this.tags.keySet()) {
+-            Tag tag = this.tags.get(key);
+-            writeNamedTag(key, tag, output);
++        // Gale start - avoid double map lookup
++        for (Entry<String, Tag> entry : this.tags.entrySet()) {
++            writeNamedTag(entry.getKey(), entry.getValue(), output);
+         }
++        // Gale end - avoid double map lookup
+ 
+         output.writeByte(0);
+     }


### PR DESCRIPTION
## Motivation

Noticed `CompoundTag#write` loops over `keySet()` and then does `tags.get(key)` for each entry — that's basically two map lookups per tag when we could just get both key and value in one pass with `entrySet()`.

This method runs a lot: every chunk save, every entity serialization, every player data save, every item metadata write. So even a small win here adds up.

## Changes

Switched the loop to use `entrySet()` instead of `keySet()` + `get()`. Same output, just one lookup instead of two. `Object2ObjectOpenHashMap` (which Paper already uses here) handles entrySet iteration efficiently.