### PR TITLE
Optimize Animal getDismountLocationForPassenger loop

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/Animal.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/Animal.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/world/entity/animal/Animal.java
++++ b/net/minecraft/world/entity/animal/Animal.java
+@@ -295,16 +_,19 @@
+         int[][] offsets = DismountHelper.offsetsForDirection(forward);
+         BlockPos vehicleBlockPos = this.blockPosition();
+         BlockPos.MutableBlockPos targetBlockPos = new BlockPos.MutableBlockPos();
++        // Gale start - hoist level lookup out of dismount pose loop
++        final Level level = this.level();
++        // Gale end - hoist level lookup out of dismount pose loop
+ 
+         for (Pose dismountPose : passenger.getDismountPoses()) {
+             AABB poseCollisionBox = passenger.getLocalBoundsForPose(dismountPose);
+ 
+             for (int[] offsetXZ : offsets) {
+                 targetBlockPos.set(vehicleBlockPos.getX() + offsetXZ[0], vehicleBlockPos.getY(), vehicleBlockPos.getZ() + offsetXZ[1]);
+-                double blockFloorHeight = this.level().getBlockFloorHeight(targetBlockPos);
++                double blockFloorHeight = level.getBlockFloorHeight(targetBlockPos);
+                 if (DismountHelper.isBlockFloorValid(blockFloorHeight)) {
+                     Vec3 location = Vec3.upFromBottomCenterOf(targetBlockPos, blockFloorHeight);
+-                    if (DismountHelper.canDismountTo(this.level(), passenger, poseCollisionBox.move(location))) {
++                    if (DismountHelper.canDismountTo(level, passenger, poseCollisionBox.move(location))) {
+                         passenger.setPose(dismountPose);
+                         return location;
+                     }
+@@ -314,4 +_,3 @@
+ 
+         return super.getDismountLocationForPassenger(passenger);
+     }
+-}

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/Animal.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/Animal.java.patch
@@ -22,8 +22,8 @@
                          passenger.setPose(dismountPose);
                          return location;
                      }
-@@ -314,4 +_,3 @@
+@@ -314,4 +_,4 @@
  
          return super.getDismountLocationForPassenger(passenger);
      }
--}
+ }


### PR DESCRIPTION
## Motivation

`Animal#getDismountLocationForPassenger` calls `this.level()` twice inside a nested loop (dismount poses × direction offsets). Since `level()` returns the same reference throughout the method, it can be hoisted to a local once.

The loop can run up to ~30 iterations depending on the passenger's dismount poses and the direction offsets, so cutting 2 virtual calls per iteration adds up when animals/vehicles are dismounted frequently.

## Changes

Hoisted `this.level()` into a local `final Level level` variable before the loops. Both call sites inside the loop now use the cached reference.