### PR TITLE
Optimize NbtUtils readBlockState property loop

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/nbt/NbtUtils.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/nbt/NbtUtils.java.patch
@@ -1,0 +1,22 @@
+--- a/net/minecraft/nbt/NbtUtils.java
++++ b/net/minecraft/nbt/NbtUtils.java
+@@ -134,14 +_,17 @@
+         BlockState result = block.defaultBlockState();
+         Optional<CompoundTag> properties = tag.getCompound("Properties");
+         if (properties.isPresent()) {
++            // Gale start - avoid repeated Optional.get() calls in loop
++            CompoundTag propertiesTag = properties.get();
+             StateDefinition<Block, BlockState> definition = block.getStateDefinition();
+ 
+-            for (String key : properties.get().keySet()) {
++            for (String key : propertiesTag.keySet()) {
+                 Property<?> property = definition.getProperty(key);
+                 if (property != null) {
+-                    result = setValueHelper(result, property, key, properties.get(), tag);
++                    result = setValueHelper(result, property, key, propertiesTag, tag);
+                 }
+             }
++            // Gale end - avoid repeated Optional.get() calls in loop
+         }
+ 
+         return result;


### PR DESCRIPTION
## Motivation

Noticed `NbtUtils#readBlockState` calls `properties.get()` twice per loop iteration once in the `for` header for `keySet()`, and once when passing it into `setValueHelper`. The Optional's presence is already checked right above, so we can just unwrap it once before the loop.

This method runs during chunk loading, structure placement, schematic parsing, etc. Not super hot per call, but avoiding repeated Optional unwrapping in a loop is cheap cleanup.

## Changes

Cached `properties.get()` into a local `CompoundTag propertiesTag` before the loop and reused it in both spots inside the loop.
