### PR TITLE
optimize empty carver passes

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
@@ -1,13 +1,37 @@
 --- a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
 +++ b/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
-@@ -58,6 +_,7 @@
+@@ -58,3 +_,5 @@
      private static final BlockState AIR = Blocks.AIR.defaultBlockState();
      private final Holder<NoiseGeneratorSettings> settings;
      private final Supplier<Aquifer.FluidPicker> globalFluidPicker;
++    private final Supplier<Boolean> hasCarvers; // Gale - Cache - NoiseBasedChunkGenerator.applyCarvers()
 +    private int cachedSeaLevel = Integer.MIN_VALUE; // Gale - Cache - NoiseBasedChunkGenerator.getSeaLevel()
- 
+
+@@ -62,5 +_,10 @@
      public NoiseBasedChunkGenerator(final BiomeSource biomeSource, final Holder<NoiseGeneratorSettings> settings) {
          super(biomeSource);
+         this.settings = settings;
+         this.globalFluidPicker = Suppliers.memoize(() -> createFluidPicker(settings.value()));
++        // Gale start - Cache - NoiseBasedChunkGenerator.applyCarvers()
++        this.hasCarvers = Suppliers.memoize(
++            () -> biomeSource.possibleBiomes().stream().anyMatch(biome -> this.generationSettingsGetter.apply(biome).getCarvers().iterator().hasNext())
++        );
++        // Gale end - Cache - NoiseBasedChunkGenerator.applyCarvers()
+     }
+@@ -310,6 +_,13 @@
+         final ChunkAccess chunk
+     ) {
+         if (!SharedConstants.DEBUG_DISABLE_CARVERS) {
++            // Gale start - Local code optimization - NoiseBasedChunkGenerator.applyCarvers() - Skip empty carver passes
++            if (!this.hasCarvers.get()) {
++                RandomSupport.generateUniqueSeed();
++                ((ProtoChunk)chunk).getOrCreateCarvingMask();
++                return;
++            }
++            // Gale end - Local code optimization - NoiseBasedChunkGenerator.applyCarvers() - Skip empty carver passes
+             BiomeManager correctBiomeManager = biomeManager.withDifferentSource(
+                 (quartX, quartY, quartZ) -> this.biomeSource.getNoiseBiome(quartX, quartY, quartZ, randomState.sampler())
+             );
 @@ -483,7 +_,12 @@
  
      @Override

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
@@ -4,7 +4,7 @@
      private static final BlockState AIR = Blocks.AIR.defaultBlockState();
      private final Holder<NoiseGeneratorSettings> settings;
      private final Supplier<Aquifer.FluidPicker> globalFluidPicker;
-+    private final Supplier<Boolean> hasCarvers; // Gale - Cache - NoiseBasedChunkGenerator.applyCarvers()
++    private final org.galemc.gale.util.function.MemoizedBooleanSupplier hasCarvers; // Gale - Cache - NoiseBasedChunkGenerator.applyCarvers()
 +    private int cachedSeaLevel = Integer.MIN_VALUE; // Gale - Cache - NoiseBasedChunkGenerator.getSeaLevel()
 
 @@ -62,5 +_,10 @@
@@ -13,7 +13,7 @@
          this.settings = settings;
          this.globalFluidPicker = Suppliers.memoize(() -> createFluidPicker(settings.value()));
 +        // Gale start - Cache - NoiseBasedChunkGenerator.applyCarvers()
-+        this.hasCarvers = Suppliers.memoize(
++        this.hasCarvers = new org.galemc.gale.util.function.MemoizedBooleanSupplier(
 +            () -> biomeSource.possibleBiomes().stream().anyMatch(biome -> this.generationSettingsGetter.apply(biome).getCarvers().iterator().hasNext())
 +        );
 +        // Gale end - Cache - NoiseBasedChunkGenerator.applyCarvers()
@@ -23,7 +23,7 @@
      ) {
          if (!SharedConstants.DEBUG_DISABLE_CARVERS) {
 +            // Gale start - Local code optimization - NoiseBasedChunkGenerator.applyCarvers() - Skip empty carver passes
-+            if (!this.hasCarvers.get()) {
++            if (!this.hasCarvers.getAsBoolean()) {
 +                RandomSupport.generateUniqueSeed();
 +                ((ProtoChunk)chunk).getOrCreateCarvingMask();
 +                return;


### PR DESCRIPTION
Caching if biome has carvers and skips 17*17 search when there's no carver on biome like end dimension. I checked biome carvers instead of checking end dimension directly so if a  datapack or custom world generator adds carvers in end,  it will still work fine