### PR TITLE
Optimize RedstoneWireEvaluator hoist pos.above() out of loop

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java.patch
@@ -23,4 +23,4 @@
  
          return Math.max(0, wireSignal - 1);
      }
--}
+}

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java.patch
@@ -19,8 +19,8 @@
                  BlockPos aboveNeighborPos = neighborPos.above();
                  wireSignal = Math.max(wireSignal, this.getWireSignal(aboveNeighborPos, level.getBlockState(aboveNeighborPos)));
              } else if (!neighborState.isRedstoneConductor(level, neighborPos)) {
-@@ -45,4 +_,3 @@
+@@ -45,4 +_,4 @@
  
-         return Math.max(0, wireSignal - 1);
-     }
-}
+        return Math.max(0, wireSignal - 1);
+    }
+ }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java.patch
@@ -1,0 +1,26 @@
+--- a/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java
++++ b/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java
+@@ -28,13 +_,16 @@
+ 
+     protected int getIncomingWireSignal(final Level level, final BlockPos pos) {
+         int wireSignal = 0;
++        // Gale start - hoist pos.above() out of loop
++        final BlockPos abovePos = pos.above();
++        final boolean aboveIsConductor = level.getBlockState(abovePos).isRedstoneConductor(level, abovePos);
++        // Gale end - hoist pos.above() out of loop
+ 
+         for (Direction direction : Direction.Plane.HORIZONTAL) {
+             BlockPos neighborPos = pos.relative(direction);
+             BlockState neighborState = level.getBlockState(neighborPos);
+             wireSignal = Math.max(wireSignal, this.getWireSignal(neighborPos, neighborState));
+-            BlockPos abovePos = pos.above();
+-            if (neighborState.isRedstoneConductor(level, neighborPos) && !level.getBlockState(abovePos).isRedstoneConductor(level, abovePos)) {
++            if (neighborState.isRedstoneConductor(level, neighborPos) && !aboveIsConductor) {
+                 BlockPos aboveNeighborPos = neighborPos.above();
+                 wireSignal = Math.max(wireSignal, this.getWireSignal(aboveNeighborPos, level.getBlockState(aboveNeighborPos)));
+             } else if (!neighborState.isRedstoneConductor(level, neighborPos)) {
+@@ -45,4 +_,3 @@
+ 
+         return Math.max(0, wireSignal - 1);
+     }
+-}

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/redstone/RedstoneWireEvaluator.java.patch
@@ -21,6 +21,6 @@
              } else if (!neighborState.isRedstoneConductor(level, neighborPos)) {
 @@ -45,4 +_,4 @@
  
-        return Math.max(0, wireSignal - 1);
-    }
+         return Math.max(0, wireSignal - 1);
+     }
  }


### PR DESCRIPTION
## Motivation

Was looking at `RedstoneWireEvaluator#getIncomingWireSignal` and noticed `pos.above()` is called inside the horizontal direction loop, even though `pos` never changes. That's 4 unnecessary `BlockPos` allocations per call, plus a redundant `getBlockState` + `isRedstoneConductor` check on the same position 4 times.

Since redstone wire evaluation runs constantly on redstone contraptions, felt like an easy win

## Changes

Pulled `pos.above()` out of the loop and cached the `isRedstoneConductor` result into a local `aboveIsConductor` boolean The loop just uses that now.
