### PR TITLE
Optimize Snowball particle loop hoisting

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/Snowball.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/Snowball.java.patch
@@ -1,0 +1,23 @@
+--- a/net/minecraft/world/entity/projectile/throwableitemprojectile/Snowball.java
++++ b/net/minecraft/world/entity/projectile/throwableitemprojectile/Snowball.java
+@@ -44,13 +_,18 @@
+     public void handleEntityEvent(final byte id) {
+         if (id == EntityEvent.DEATH) {
+             ParticleOptions particle = this.getParticle();
++            // Gale start - hoist level lookup and position out of particle loop
++            final Level level = this.level();
++            final double x = this.getX();
++            final double y = this.getY();
++            final double z = this.getZ();
+ 
+             for (int i = 0; i < 8; i++) {
+-                this.level().addParticle(particle, this.getX(), this.getY(), this.getZ(), 0.0, 0.0, 0.0);
++                level.addParticle(particle, x, y, z, 0.0, 0.0, 0.0);
+             }
++            // Gale end - hoist level lookup and position out of particle loop
+         }
+     }
+-
+     @Override
+     protected void onHitEntity(final EntityHitResult hitResult) {
+         super.onHitEntity(hitResult);


### PR DESCRIPTION
## Motivation

Was looking at `Snowball#handleEntityEvent` and noticed the death particle loop calls `this.level()`, `this.getX()`, `this.getY()`, and `this.getZ()` inside every iteration — 8 times each. Since none of those change during the loop, it's just 28 redundant virtual calls per snowball death.

Snowball hits are pretty common on PVP servers, snow golem farms, etc, so felt like an easy win.

## Changes

Pulled `this.level()` and the position into locals before the loop and used them inside instead.

Same particles, less repeated work.
