### PR TITLE
Optimize entity tick hot paths - hoist level() lookup

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java.patch
@@ -1,0 +1,39 @@
+--- a/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java
++++ b/net/minecraft/world/entity/boss/enderdragon/EndCrystal.java
+@@ -53,24 +_,27 @@
+ 
+     @Override
+     public void tick() {
++        // Gale start - hoist level lookup
++        final Level level = this.level();
++        // Gale end - hoist level lookup
+         this.time++;
+         this.applyEffectsFromBlocks();
+         this.handlePortal();
+-        if (this.level() instanceof ServerLevel) {
++        if (level instanceof ServerLevel serverLevel) {
+             BlockPos pos = this.blockPosition();
+-            if (((ServerLevel)this.level()).getDragonFight() != null && this.level().getBlockState(pos).isAir()) {
+-                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBlockIgniteEvent(this.level(), pos, this).isCancelled()) { // Paper
+-                this.level().setBlockAndUpdate(pos, BaseFireBlock.getState(this.level(), pos));
++            if (serverLevel.getDragonFight() != null && level.getBlockState(pos).isAir()) {
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBlockIgniteEvent(level, pos, this).isCancelled()) { // Paper
++                    level.setBlockAndUpdate(pos, BaseFireBlock.getState(level, pos));
+                 } // Paper
+             }
+         }
+ 
+         // Paper start - Fix invulnerable end crystals
+-        if (this.level().paperConfig().unsupportedSettings.fixInvulnerableEndCrystalExploit && this.generatedByDragonFight && this.isInvulnerable()) {
+-            if (!java.util.Objects.equals(((ServerLevel) this.level()).uuid, this.originWorld)
+-                || ((ServerLevel) this.level()).getDragonFight() == null
+-                || ((ServerLevel) this.level()).getDragonFight().respawnStage == null
+-                || ((ServerLevel) this.level()).getDragonFight().respawnStage.ordinal() > net.minecraft.world.level.dimension.end.DragonRespawnStage.SUMMONING_DRAGON.ordinal()) {
++        if (level.paperConfig().unsupportedSettings.fixInvulnerableEndCrystalExploit && this.generatedByDragonFight && this.isInvulnerable()) {
++            if (level instanceof ServerLevel serverLevelInvulnerable && (!java.util.Objects.equals(serverLevelInvulnerable.uuid, this.originWorld)
++                || serverLevelInvulnerable.getDragonFight() == null
++                || serverLevelInvulnerable.getDragonFight().respawnStage == null
++                || serverLevelInvulnerable.getDragonFight().respawnStage.ordinal() > net.minecraft.world.level.dimension.end.DragonRespawnStage.SUMMONING_DRAGON.ordinal())) {
+                 this.setInvulnerable(false);
+                 this.setBeamTarget(null);
+             }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/item/PrimedTnt.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/item/PrimedTnt.java.patch
@@ -1,0 +1,43 @@
+--- a/net/minecraft/world/entity/item/PrimedTnt.java
++++ b/net/minecraft/world/entity/item/PrimedTnt.java
+@@ -105,12 +_,15 @@
+     @Override
+     public void tick() {
+         if (this.level().spigotConfig.maxTntTicksPerTick > 0 && ++this.level().spigotConfig.currentPrimedTnt > this.level().spigotConfig.maxTntTicksPerTick) { return; } // Spigot
++        // Gale start - hoist level lookup
++        final Level level = this.level();
++        // Gale end - hoist level lookup
+         this.handlePortal();
+         this.applyGravity();
+         this.move(MoverType.SELF, this.getDeltaMovement());
+         this.applyEffectsFromBlocks();
+         // Paper start - Configurable TNT height nerf
+-        if (this.level().paperConfig().fixes.tntEntityHeightNerf.test(v -> this.getY() > v)) {
++        if (level.paperConfig().fixes.tntEntityHeightNerf.test(v -> this.getY() > v)) {
+             this.discard(EntityRemoveEvent.Cause.OUT_OF_WORLD);
+             return;
+         }
+@@ -125,19 +_,19 @@
+         if (fuse <= 0) {
+             // CraftBukkit start - Need to reverse the order of the explosion and the entity death so we have a location for the event
+             //this.discard();
+-            if (!this.level().isClientSide()) {
++            if (!level.isClientSide()) {
+                 this.explode();
+             }
+             this.discard(EntityRemoveEvent.Cause.EXPLODE); // CraftBukkit - add Bukkit remove cause
+             // CraftBukkit end
+         } else {
+             this.updateFluidInteraction();
+-            if (this.level().isClientSide()) {
+-                this.level().addParticle(ParticleTypes.SMOKE, this.getX(), this.getY() + 0.5, this.getZ(), 0.0, 0.0, 0.0);
++            if (level.isClientSide()) {
++                level.addParticle(ParticleTypes.SMOKE, this.getX(), this.getY() + 0.5, this.getZ(), 0.0, 0.0, 0.0);
+             }
+         }
+         // Paper start - Option to prevent TNT from moving in water
+-        if (!this.isRemoved() && this.wasTouchingWater && this.level().paperConfig().fixes.preventTntFromMovingInWater) {
++        if (!this.isRemoved() && this.wasTouchingWater && level.paperConfig().fixes.preventTntFromMovingInWater) {
+             this.hurtMarked = true;
+             this.needsSync = true;
+         }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/FireworkRocketEntity.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/FireworkRocketEntity.java.patch
@@ -1,0 +1,47 @@
+--- a/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
++++ b/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
+@@ -130,11 +_,14 @@
+     @Override
+     public void tick() {
+         super.tick();
++        // Gale start - hoist level lookup
++        final Level level = this.level();
++        // Gale end - hoist level lookup
+         HitResult hitResult;
+         if (this.isAttachedToEntity()) {
+             if (this.attachedToEntity == null) {
+                 this.entityData.get(DATA_ATTACHED_TO_TARGET).ifPresent(id -> {
+-                    if (this.level().getEntity(id) instanceof LivingEntity livingEntity) {
++                    if (level.getEntity(id) instanceof LivingEntity livingEntity) {
+                         this.attachedToEntity = livingEntity;
+                     }
+                 });
+@@ -185,12 +_,12 @@
+ 
+         this.updateRotation();
+         if (this.life == 0 && !this.isSilent()) {
+-            this.level().playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.FIREWORK_ROCKET_LAUNCH, SoundSource.AMBIENT, 3.0F, 1.0F);
++            level.playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.FIREWORK_ROCKET_LAUNCH, SoundSource.AMBIENT, 3.0F, 1.0F);
+         }
+ 
+         this.life++;
+-        if (this.level().isClientSide() && this.life % 2 < 2) {
+-            this.level()
++        if (level.isClientSide() && this.life % 2 < 2) {
++            level
+                 .addParticle(
+                     ParticleTypes.FIREWORK,
+                     this.getX(),
+@@ -202,10 +_,10 @@
+                 );
+         }
+ 
+-        if (this.life > this.lifetime && this.level() instanceof ServerLevel level) {
++        if (this.life > this.lifetime && level instanceof ServerLevel serverLevel) {
+             // Paper start - Call FireworkExplodeEvent
+             if (org.bukkit.craftbukkit.event.CraftEventFactory.callFireworkExplodeEvent(this)) {
+-                this.explode(level);
++                this.explode(serverLevel);
+             }
+             // Paper end - Call FireworkExplodeEvent
+         }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/ShulkerBullet.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/ShulkerBullet.java.patch
@@ -1,0 +1,37 @@
+--- a/net/minecraft/world/entity/projectile/ShulkerBullet.java
++++ b/net/minecraft/world/entity/projectile/ShulkerBullet.java
+@@ -203,9 +_,12 @@
+     @Override
+     public void tick() {
+         super.tick();
+-        Entity finalTarget = !this.level().isClientSide() ? EntityReference.getEntity(this.finalTarget, this.level()) : null;
++        // Gale start - hoist level lookup
++        final Level level = this.level();
++        // Gale end - hoist level lookup
++        Entity finalTarget = !level.isClientSide() ? EntityReference.getEntity(this.finalTarget, level) : null;
+         HitResult hitResult = null;
+-        if (!this.level().isClientSide()) {
++        if (!level.isClientSide()) {
+             if (finalTarget == null) {
+                 this.finalTarget = null;
+             }
+@@ -237,8 +_,8 @@
+         }
+ 
+         ProjectileUtil.rotateTowardsMovement(this, 0.5F);
+-        if (this.level().isClientSide()) {
+-            this.level().addParticle(ParticleTypes.END_ROD, this.getX() - movement.x, this.getY() - movement.y + 0.15, this.getZ() - movement.z, 0.0, 0.0, 0.0);
++        if (level.isClientSide()) {
++            level.addParticle(ParticleTypes.END_ROD, this.getX() - movement.x, this.getY() - movement.y + 0.15, this.getZ() - movement.z, 0.0, 0.0, 0.0);
+         } else if (finalTarget != null) {
+             if (this.flightSteps > 0) {
+                 this.flightSteps--;
+@@ -250,7 +_,7 @@
+             if (this.currentMoveDirection != null) {
+                 BlockPos current = this.blockPosition();
+                 Direction.Axis axis = this.currentMoveDirection.getAxis();
+-                if (this.level().loadedAndEntityCanStandOn(current.relative(this.currentMoveDirection), this)) {
++                if (level.loadedAndEntityCanStandOn(current.relative(this.currentMoveDirection), this)) {
+                     this.selectNextMoveDirection(axis, finalTarget);
+                 } else {
+                     BlockPos targetPos = finalTarget.blockPosition();


### PR DESCRIPTION
## Motivation

Noticed a common pattern across a few entity `tick()` methods — they call `this.level()` multiple times per tick even though the returned reference doesn't change during the call. On servers with lots of these entities (TNT farms, end crystal setups, shulker fights, elytra players with rockets) those redundant virtual calls add up.

## Changes

Hoisted `this.level()` into a local `final Level level` variable at the top of each `tick()` method in:

- `EndCrystal` — 3 `this.level()` calls consolidated
- `PrimedTnt` — 5 `this.level()` calls consolidated
- `ShulkerBullet` — 5 `this.level()` calls consolidated
- `FireworkRocketEntity` — 4 `this.level()` calls consolidated

Also used pattern matching (`level instanceof ServerLevel serverLevel`) where a cast was previously being repeated, so the `ServerLevel` reference is available cleanly inside those branches.