### PR TITLE
Optimize Villager food inventory checks

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/npc/villager/Villager.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/npc/villager/Villager.java.patch
@@ -1,0 +1,42 @@
+--- a/net/minecraft/world/entity/npc/villager/Villager.java
++++ b/net/minecraft/world/entity/npc/villager/Villager.java
+@@ -697,8 +_,12 @@
+ 
+     private void eatUntilFull() {
+         if (this.hungry() && this.countFoodPointsInInventory() != 0) {
+-            for (int slot = 0; slot < this.getInventory().getContainerSize(); slot++) {
+-                ItemStack itemStack = this.getInventory().getItem(slot);
++            // Gale start - hoist inventory lookup
++            final SimpleContainer inventory = this.getInventory();
++            final int containerSize = inventory.getContainerSize();
++            // Gale end - hoist inventory lookup
++            for (int slot = 0; slot < containerSize; slot++) {
++                ItemStack itemStack = inventory.getItem(slot);
+                 if (!itemStack.isEmpty()) {
+                     Integer value = FOOD_POINTS.get(itemStack.getItem());
+                     if (value != null) {
+@@ -706,7 +_,7 @@
+ 
+                         for (int count = itemCount; count > 0; count--) {
+                             this.foodLevel = this.foodLevel + value;
+-                            this.getInventory().removeItem(slot, 1);
++                            inventory.removeItem(slot, 1);
+                             if (!this.hungry()) {
+                                 return;
+                             }
+@@ -843,8 +_,14 @@
+     }
+ 
+     private int countFoodPointsInInventory() {
++        // Gale start - avoid stream in villager food check
+         SimpleContainer inventory = this.getInventory();
+-        return FOOD_POINTS.entrySet().stream().mapToInt(entry -> inventory.countItem(entry.getKey()) * entry.getValue()).sum();
++        int total = 0;
++        for (Map.Entry<Item, Integer> entry : FOOD_POINTS.entrySet()) {
++            total += inventory.countItem(entry.getKey()) * entry.getValue();
++        }
++        return total;
++        // Gale end - avoid stream in villager food check
+     }
+ 
+     public boolean hasFarmSeeds() {

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/npc/villager/Villager.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/npc/villager/Villager.java.patch
@@ -1,29 +1,5 @@
 --- a/net/minecraft/world/entity/npc/villager/Villager.java
 +++ b/net/minecraft/world/entity/npc/villager/Villager.java
-@@ -697,8 +_,12 @@
- 
-     private void eatUntilFull() {
-         if (this.hungry() && this.countFoodPointsInInventory() != 0) {
--            for (int slot = 0; slot < this.getInventory().getContainerSize(); slot++) {
--                ItemStack itemStack = this.getInventory().getItem(slot);
-+            // Gale start - hoist inventory lookup
-+            final SimpleContainer inventory = this.getInventory();
-+            final int containerSize = inventory.getContainerSize();
-+            // Gale end - hoist inventory lookup
-+            for (int slot = 0; slot < containerSize; slot++) {
-+                ItemStack itemStack = inventory.getItem(slot);
-                 if (!itemStack.isEmpty()) {
-                     Integer value = FOOD_POINTS.get(itemStack.getItem());
-                     if (value != null) {
-@@ -706,7 +_,7 @@
- 
-                         for (int count = itemCount; count > 0; count--) {
-                             this.foodLevel = this.foodLevel + value;
--                            this.getInventory().removeItem(slot, 1);
-+                            inventory.removeItem(slot, 1);
-                             if (!this.hungry()) {
-                                 return;
-                             }
 @@ -843,8 +_,14 @@
      }
  

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/npc/villager/Villager.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/npc/villager/Villager.java.patch
@@ -1,18 +1,35 @@
 --- a/net/minecraft/world/entity/npc/villager/Villager.java
 +++ b/net/minecraft/world/entity/npc/villager/Villager.java
-@@ -843,8 +_,14 @@
+@@ -688,7 +_,9 @@
+ 
+     @Override
+     public boolean canBreed() {
+-        return this.foodLevel + this.countFoodPointsInInventory() >= 12 && !this.isSleeping() && this.getAge() == 0;
++        // Gale start - Local code optimization - skip inventory scan if food level sufficient
++        return (this.foodLevel >= 12 || this.foodLevel + this.countFoodPointsInInventory() >= 12) && !this.isSleeping() && this.getAge() == 0;
++        // Gale end - Local code optimization - skip inventory scan if food level sufficient
+     }
+ 
+     private boolean hungry() {
+@@ -843,8 +_,20 @@
      }
  
      private int countFoodPointsInInventory() {
-+        // Gale start - avoid stream in villager food check
++        // Gale start - Local code optimization - single pass food point count
          SimpleContainer inventory = this.getInventory();
 -        return FOOD_POINTS.entrySet().stream().mapToInt(entry -> inventory.countItem(entry.getKey()) * entry.getValue()).sum();
 +        int total = 0;
-+        for (Map.Entry<Item, Integer> entry : FOOD_POINTS.entrySet()) {
-+            total += inventory.countItem(entry.getKey()) * entry.getValue();
++        for (int slot = 0; slot < inventory.getContainerSize(); slot++) {
++            ItemStack itemStack = inventory.getItem(slot);
++            if (!itemStack.isEmpty()) {
++                Integer points = FOOD_POINTS.get(itemStack.getItem());
++                if (points != null) {
++                    total += points * itemStack.getCount();
++                }
++            }
 +        }
 +        return total;
-+        // Gale end - avoid stream in villager food check
++        // Gale end - Local code optimization - single pass food point count
      }
  
      public boolean hasFarmSeeds() {


### PR DESCRIPTION
## Motivation

`countFoodPointsInInventory()` was scanning the entire inventory 4 times (once per food type) using `countItem()` for each entry in `FOOD_POINTS`. Replaced with a single pass over inventory slots, checking each item against `FOOD_POINTS` — same result, one scan instead of four.

Also added a short circuit in `canBreed()` — if `foodLevel` is already >= 12, skip the inventory scan entirely since it's not needed.

## Changes

- `countFoodPointsInInventory()` — single inventory pass instead of 4 separate `countItem` scans. Added "Local code optimization" category label per Gale convention.
- `canBreed()` — short circuit when `foodLevel >= 12` to avoid unnecessary inventory scan.

