### PR TITLE
Fix potential ArrayIndexOutOfBoundsException in SpatialGrid.containsKey()

### DIFF
--- a/gale-server/src/main/java/org/galemc/gale/util/collection/spatialgrid/despawn/point/SpatialGrid.java
+++ b/gale-server/src/main/java/org/galemc/gale/util/collection/spatialgrid/despawn/point/SpatialGrid.java
@@ -673,6 +673,6 @@ public abstract class SpatialGrid implements AbstractSpatialGrid {
     @Override
     public double getZ(int slot) { return zs[slot]; }
     @Override
-    public boolean containsKey(int slot) { return slot < this.slotPackedCell.length && this.slotPackedCell[slot] != SLOT_EMPTY; }
+    public boolean containsKey(int slot) { return slot >= 0 && slot < this.slotPackedCell.length && this.slotPackedCell[slot] != SLOT_EMPTY; }
 
 }


### PR DESCRIPTION
SpatialGrid.containsKey() crashes with ArrayIndexOutOfBoundsException when a negative slot value is passed. Added a negative check.