### PR TITLE
Remove redundant inline slot checks in spatial queries

### DIFF
--- a/gale-server/src/main/java/org/galemc/gale/util/collection/spatialgrid/despawn/point/CylinderSpatialGrid.java
+++ b/gale-server/src/main/java/org/galemc/gale/util/collection/spatialgrid/despawn/point/CylinderSpatialGrid.java
@@ -36,10 +36,10 @@ public final class CylinderSpatialGrid extends SpatialGrid {
                     if (!aabbIntersectsCylinder(idx, cxD, cyD, czD)) continue;
                     int cnt = inlineCount[idx];
                     if (cnt > 0) {
-                        if (inline0[idx] != -1 && pointInCylinderSlot(inline0[idx], cxD, cyD, czD)) return inline0[idx];
-                        if (cnt >= 2 && inline1[idx] != -1 && pointInCylinderSlot(inline1[idx], cxD, cyD, czD)) return inline1[idx];
-                        if (cnt >= 3 && inline2[idx] != -1 && pointInCylinderSlot(inline2[idx], cxD, cyD, czD)) return inline2[idx];
-                        if (cnt >= 4 && inline3[idx] != -1 && pointInCylinderSlot(inline3[idx], cxD, cyD, czD)) return inline3[idx];
+                        if (pointInCylinderSlot(inline0[idx], cxD, cyD, czD)) return inline0[idx];
+                        if (cnt >= 2 && pointInCylinderSlot(inline1[idx], cxD, cyD, czD)) return inline1[idx];
+                        if (cnt >= 3 && pointInCylinderSlot(inline2[idx], cxD, cyD, czD)) return inline2[idx];
+                        if (cnt >= 4 && pointInCylinderSlot(inline3[idx], cxD, cyD, czD)) return inline3[idx];
                     }
                     int h = overflowHead[idx];
                     while (h != -1) {
@@ -69,29 +69,27 @@ public final class CylinderSpatialGrid extends SpatialGrid {
                     if (!aabbIntersectsCylinder(idx, cxD, cyD, czD)) continue;
                     int cnt = inlineCount[idx];
                     if (cnt > 0) {
-                        if (inline0[idx] != -1) {
-                            int s = inline0[idx];
+                        int s = inline0[idx];
+                        if (pointInCylinderSlot(s, cxD, cyD, czD)) {
+                            double dd = dist2SlotPlanar(s, cxD, czD);
+                            if (dd < best) { best = dd; bestSlot = s; }
+                        }
+                        if (cnt >= 2) {
+                            s = inline1[idx];
                             if (pointInCylinderSlot(s, cxD, cyD, czD)) {
                                 double dd = dist2SlotPlanar(s, cxD, czD);
                                 if (dd < best) { best = dd; bestSlot = s; }
                             }
                         }
-                        if (cnt >= 2 && inline1[idx] != -1) {
-                            int s = inline1[idx];
+                        if (cnt >= 3) {
+                            s = inline2[idx];
                             if (pointInCylinderSlot(s, cxD, cyD, czD)) {
                                 double dd = dist2SlotPlanar(s, cxD, czD);
                                 if (dd < best) { best = dd; bestSlot = s; }
                             }
                         }
-                        if (cnt >= 3 && inline2[idx] != -1) {
-                            int s = inline2[idx];
-                            if (pointInCylinderSlot(s, cxD, cyD, czD)) {
-                                double dd = dist2SlotPlanar(s, cxD, czD);
-                                if (dd < best) { best = dd; bestSlot = s; }
-                            }
-                        }
-                        if (cnt >= 4 && inline3[idx] != -1) {
-                            int s = inline3[idx];
+                        if (cnt >= 4) {
+                            s = inline3[idx];
                             if (pointInCylinderSlot(s, cxD, cyD, czD)) {
                                 double dd = dist2SlotPlanar(s, cxD, czD);
                                 if (dd < best) { best = dd; bestSlot = s; }
@@ -116,7 +114,6 @@ public final class CylinderSpatialGrid extends SpatialGrid {
     // ---------------- AABB helpers ----------------
 
     private boolean aabbIntersectsCylinder(int idx, double cxD, double cyD, double czD) {
-        if (inlineCount[idx] == 0 && overflowHead[idx] == -1) return false;
         double minx = bMinX[idx], maxx = bMaxX[idx];
         double miny = bMinY[idx], maxy = bMaxY[idx];
         double minz = bMinZ[idx], maxz = bMaxZ[idx];

--- a/gale-server/src/main/java/org/galemc/gale/util/collection/spatialgrid/despawn/point/EllipsoidSpatialGrid.java
+++ b/gale-server/src/main/java/org/galemc/gale/util/collection/spatialgrid/despawn/point/EllipsoidSpatialGrid.java
@@ -35,10 +35,10 @@ public final class EllipsoidSpatialGrid extends SpatialGrid {
                     if (!aabbIntersectsEllipsoid(idx, cxD, cyD, czD)) continue;
                     int cnt = inlineCount[idx];
                     if (cnt > 0) {
-                        if (inline0[idx] != -1 && pointInEllipsoidSlot(inline0[idx], cxD, cyD, czD)) return inline0[idx];
-                        if (cnt >= 2 && inline1[idx] != -1 && pointInEllipsoidSlot(inline1[idx], cxD, cyD, czD)) return inline1[idx];
-                        if (cnt >= 3 && inline2[idx] != -1 && pointInEllipsoidSlot(inline2[idx], cxD, cyD, czD)) return inline2[idx];
-                        if (cnt >= 4 && inline3[idx] != -1 && pointInEllipsoidSlot(inline3[idx], cxD, cyD, czD)) return inline3[idx];
+                        if (pointInEllipsoidSlot(inline0[idx], cxD, cyD, czD)) return inline0[idx];
+                        if (cnt >= 2 && pointInEllipsoidSlot(inline1[idx], cxD, cyD, czD)) return inline1[idx];
+                        if (cnt >= 3 && pointInEllipsoidSlot(inline2[idx], cxD, cyD, czD)) return inline2[idx];
+                        if (cnt >= 4 && pointInEllipsoidSlot(inline3[idx], cxD, cyD, czD)) return inline3[idx];
                     }
                     int h = overflowHead[idx];
                     while (h != -1) {
@@ -68,29 +68,27 @@ public final class EllipsoidSpatialGrid extends SpatialGrid {
                     if (!aabbIntersectsEllipsoid(idx, cxD, cyD, czD)) continue;
                     int cnt = inlineCount[idx];
                     if (cnt > 0) {
-                        if (inline0[idx] != -1) {
-                            int s = inline0[idx];
+                        int s = inline0[idx];
+                        if (pointInEllipsoidSlot(s, cxD, cyD, czD)) {
+                            double dd = dist2SlotToCenter(s, cxD, cyD, czD);
+                            if (dd < best) { best = dd; bestSlot = s; }
+                        }
+                        if (cnt >= 2) {
+                            s = inline1[idx];
                             if (pointInEllipsoidSlot(s, cxD, cyD, czD)) {
                                 double dd = dist2SlotToCenter(s, cxD, cyD, czD);
                                 if (dd < best) { best = dd; bestSlot = s; }
                             }
                         }
-                        if (cnt >= 2 && inline1[idx] != -1) {
-                            int s = inline1[idx];
+                        if (cnt >= 3) {
+                            s = inline2[idx];
                             if (pointInEllipsoidSlot(s, cxD, cyD, czD)) {
                                 double dd = dist2SlotToCenter(s, cxD, cyD, czD);
                                 if (dd < best) { best = dd; bestSlot = s; }
                             }
                         }
-                        if (cnt >= 3 && inline2[idx] != -1) {
-                            int s = inline2[idx];
-                            if (pointInEllipsoidSlot(s, cxD, cyD, czD)) {
-                                double dd = dist2SlotToCenter(s, cxD, cyD, czD);
-                                if (dd < best) { best = dd; bestSlot = s; }
-                            }
-                        }
-                        if (cnt >= 4 && inline3[idx] != -1) {
-                            int s = inline3[idx];
+                        if (cnt >= 4) {
+                            s = inline3[idx];
                             if (pointInEllipsoidSlot(s, cxD, cyD, czD)) {
                                 double dd = dist2SlotToCenter(s, cxD, cyD, czD);
                                 if (dd < best) { best = dd; bestSlot = s; }
@@ -115,7 +113,6 @@ public final class EllipsoidSpatialGrid extends SpatialGrid {
     // ---------------- AABB helpers ----------------
 
     private boolean aabbIntersectsEllipsoid(int idx, double cxD, double cyD, double czD) {
-        if (inlineCount[idx] == 0 && overflowHead[idx] == -1) return false;
         double minx = bMinX[idx], maxx = bMaxX[idx];
         double miny = bMinY[idx], maxy = bMaxY[idx];
         double minz = bMinZ[idx], maxz = bMaxZ[idx];


### PR DESCRIPTION
Remove inlineN != -1 checks that are always true when cnt > N. Also remove dead empty-bucket check from aabbIntersects - the bucket is guaranteed non-empty by the hash table lookup.