### PR TITLE
Add EntityCollectionUtil with thread-local reusable lists

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -304,7 +304,7 @@
 +    @Override
 +    public List<Entity> getEntities(@Nullable Entity except, AABB area) {
 +        List<Entity> list = org.galemc.gale.util.entity.EntityCollectionUtil.getEntityList();
-+        ((ServerLevel)this).getEntityLookup().getEntities(except, area, list, EntitySelector.NO_SPECTATORS);
++        this.getEntities().getEntities(net.minecraft.world.level.entity.EntityTypeTest.forClass(Entity.class), area, EntitySelector.NO_SPECTATORS, list, Integer.MAX_VALUE);
 +        return list;
 +    }
 +    // Gale end - use reusable entity list

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -288,20 +288,7 @@
          this.tickingBlockEntities = true;
          if (!this.pendingBlockEntityTickers.isEmpty()) {
              this.blockEntityTickers.addAll(this.pendingBlockEntityTickers);
-@@ -1515,4 +_,14 @@
-     }
-     
-+    // Gale start - use thread-local reusable list
-+    @Override
-+    public List<Entity> getEntities(@Nullable Entity except, AABB area) {
-+        List<Entity> list = org.galemc.gale.util.entity.EntityCollectionUtil.getEntityList();
-+        ((ServerLevel)this).getEntityLookup().getEntities(except, area, list, EntitySelector.NO_SPECTATORS);
-+        return list;
-+    }
-+    // Gale end - use thread-local reusable list
-     @Override
-     public List<Entity> getEntities(@Nullable Entity except, AABB box, Predicate<? super Entity> predicate) {
-@@ -2127,6 +_,13 @@
+@@ -2127,6 +_,22 @@
      public BiomeManager getBiomeManager() {
          return this.biomeManager;
      }
@@ -313,5 +300,14 @@
 +    }
 +    // Gale end - Cache - BiomeManager.getBiome()
  
++    // Gale start - use reusable entity list
++    @Override
++    public List<Entity> getEntities(@Nullable Entity except, AABB area) {
++        List<Entity> list = org.galemc.gale.util.entity.EntityCollectionUtil.getEntityList();
++        ((ServerLevel)this).getEntityLookup().getEntities(except, area, list, EntitySelector.NO_SPECTATORS);
++        return list;
++    }
++    // Gale end - use reusable entity list
      public final boolean isDebug() {
          return this.isDebug;
+

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -310,4 +310,3 @@
 +    // Gale end - use reusable entity list
      public final boolean isDebug() {
          return this.isDebug;
-

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -304,7 +304,12 @@
 +    @Override
 +    public List<Entity> getEntities(@Nullable Entity except, AABB area) {
 +        List<Entity> list = org.galemc.gale.util.entity.EntityCollectionUtil.getEntityList();
-+        this.getEntities().get(net.minecraft.world.level.entity.EntityTypeTest.forClass(Entity.class), area, EntitySelector.NO_SPECTATORS, list, Integer.MAX_VALUE);
++        this.getEntities().get(net.minecraft.world.level.entity.EntityTypeTest.forClass(Entity.class), area, (net.minecraft.util.AbortableIterationConsumer<Entity>) entity -> {
++            if (entity != except && !entity.isSpectator()) {
++                list.add(entity);
++            }
++            return net.minecraft.util.AbortableIterationConsumer.Continuation.CONTINUE;
++        });
 +        return list;
 +    }
 +    // Gale end - use reusable entity list

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -304,7 +304,7 @@
 +    @Override
 +    public List<Entity> getEntities(@Nullable Entity except, AABB area) {
 +        List<Entity> list = org.galemc.gale.util.entity.EntityCollectionUtil.getEntityList();
-+        this.getEntities().getEntities(net.minecraft.world.level.entity.EntityTypeTest.forClass(Entity.class), area, EntitySelector.NO_SPECTATORS, list, Integer.MAX_VALUE);
++        this.getEntities().get(net.minecraft.world.level.entity.EntityTypeTest.forClass(Entity.class), area, EntitySelector.NO_SPECTATORS, list, Integer.MAX_VALUE);
 +        return list;
 +    }
 +    // Gale end - use reusable entity list

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -288,6 +288,19 @@
          this.tickingBlockEntities = true;
          if (!this.pendingBlockEntityTickers.isEmpty()) {
              this.blockEntityTickers.addAll(this.pendingBlockEntityTickers);
+@@ -1515,4 +_,14 @@
+     }
+     
++    // Gale start - use thread-local reusable list
++    @Override
++    public List<Entity> getEntities(@Nullable Entity except, AABB area) {
++        List<Entity> list = org.galemc.gale.util.entity.EntityCollectionUtil.getEntityList();
++        ((ServerLevel)this).getEntityLookup().getEntities(except, area, list, EntitySelector.NO_SPECTATORS);
++        return list;
++    }
++    // Gale end - use thread-local reusable list
+     @Override
+     public List<Entity> getEntities(@Nullable Entity except, AABB box, Predicate<? super Entity> predicate) {
 @@ -2127,6 +_,13 @@
      public BiomeManager getBiomeManager() {
          return this.biomeManager;

--- a/gale-server/src/main/java/org/galemc/gale/util/entity/EntityCollectionUtil.java
+++ b/gale-server/src/main/java/org/galemc/gale/util/entity/EntityCollectionUtil.java
@@ -1,0 +1,34 @@
+package org.galemc.gale.util.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+public final class EntityCollectionUtil {
+
+    private static final ThreadLocal<List<Entity>> ENTITY_LIST = ThreadLocal.withInitial(ArrayList::new);
+    private static final ThreadLocal<List<VoxelShape>> VOXEL_SHAPE_LIST = ThreadLocal.withInitial(ArrayList::new);
+    private static final ThreadLocal<List<AABB>> AABB_LIST = ThreadLocal.withInitial(ArrayList::new);
+
+    private EntityCollectionUtil() {}
+
+    public static List<Entity> getEntityList() {
+        List<Entity> list = ENTITY_LIST.get();
+        list.clear();
+        return list;
+    }
+
+    public static List<VoxelShape> getVoxelShapeList() {
+        List<VoxelShape> list = VOXEL_SHAPE_LIST.get();
+        list.clear();
+        return list;
+    }
+
+    public static List<AABB> getAABBList() {
+        List<AABB> list = AABB_LIST.get();
+        list.clear();
+        return list;
+    }
+}

--- a/gale-server/src/main/java/org/galemc/gale/util/entity/EntityCollectionUtil.java
+++ b/gale-server/src/main/java/org/galemc/gale/util/entity/EntityCollectionUtil.java
@@ -11,27 +11,24 @@ public final class EntityCollectionUtil {
     private static final int EXPECTED_ENTITIES = 64;
     private static final int EXPECTED_COLLISIONS = 32;
 
-    private static final ThreadLocal<List<Entity>> ENTITY_LIST = ThreadLocal.withInitial(() -> new ArrayList<>(EXPECTED_ENTITIES));
-    private static final ThreadLocal<List<VoxelShape>> VOXEL_SHAPE_LIST = ThreadLocal.withInitial(() -> new ArrayList<>(EXPECTED_COLLISIONS));
-    private static final ThreadLocal<List<AABB>> AABB_LIST = ThreadLocal.withInitial(() -> new ArrayList<>(EXPECTED_COLLISIONS));
+    private static final List<Entity> ENTITY_LIST = new ArrayList<>(EXPECTED_ENTITIES);
+    private static final List<VoxelShape> VOXEL_SHAPE_LIST = new ArrayList<>(EXPECTED_COLLISIONS);
+    private static final List<AABB> AABB_LIST = new ArrayList<>(EXPECTED_COLLISIONS);
 
     private EntityCollectionUtil() {}
 
     public static List<Entity> getEntityList() {
-        List<Entity> list = ENTITY_LIST.get();
-        list.clear();
-        return list;
+        ENTITY_LIST.clear();
+        return ENTITY_LIST;
     }
 
     public static List<VoxelShape> getVoxelShapeList() {
-        List<VoxelShape> list = VOXEL_SHAPE_LIST.get();
-        list.clear();
-        return list;
+        VOXEL_SHAPE_LIST.clear();
+        return VOXEL_SHAPE_LIST;
     }
 
     public static List<AABB> getAABBList() {
-        List<AABB> list = AABB_LIST.get();
-        list.clear();
-        return list;
+        AABB_LIST.clear();
+        return AABB_LIST;
     }
 }

--- a/gale-server/src/main/java/org/galemc/gale/util/entity/EntityCollectionUtil.java
+++ b/gale-server/src/main/java/org/galemc/gale/util/entity/EntityCollectionUtil.java
@@ -8,9 +8,12 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 
 public final class EntityCollectionUtil {
 
-    private static final ThreadLocal<List<Entity>> ENTITY_LIST = ThreadLocal.withInitial(ArrayList::new);
-    private static final ThreadLocal<List<VoxelShape>> VOXEL_SHAPE_LIST = ThreadLocal.withInitial(ArrayList::new);
-    private static final ThreadLocal<List<AABB>> AABB_LIST = ThreadLocal.withInitial(ArrayList::new);
+    private static final int EXPECTED_ENTITIES = 64;
+    private static final int EXPECTED_COLLISIONS = 32;
+
+    private static final ThreadLocal<List<Entity>> ENTITY_LIST = ThreadLocal.withInitial(() -> new ArrayList<>(EXPECTED_ENTITIES));
+    private static final ThreadLocal<List<VoxelShape>> VOXEL_SHAPE_LIST = ThreadLocal.withInitial(() -> new ArrayList<>(EXPECTED_COLLISIONS));
+    private static final ThreadLocal<List<AABB>> AABB_LIST = ThreadLocal.withInitial(() -> new ArrayList<>(EXPECTED_COLLISIONS));
 
     private EntityCollectionUtil() {}
 

--- a/gale-server/src/main/java/org/galemc/gale/util/entity/EntityCollectionUtil.java
+++ b/gale-server/src/main/java/org/galemc/gale/util/entity/EntityCollectionUtil.java
@@ -3,32 +3,17 @@ package org.galemc.gale.util.entity;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 public final class EntityCollectionUtil {
 
     private static final int EXPECTED_ENTITIES = 64;
-    private static final int EXPECTED_COLLISIONS = 32;
 
     private static final List<Entity> ENTITY_LIST = new ArrayList<>(EXPECTED_ENTITIES);
-    private static final List<VoxelShape> VOXEL_SHAPE_LIST = new ArrayList<>(EXPECTED_COLLISIONS);
-    private static final List<AABB> AABB_LIST = new ArrayList<>(EXPECTED_COLLISIONS);
 
     private EntityCollectionUtil() {}
 
     public static List<Entity> getEntityList() {
         ENTITY_LIST.clear();
         return ENTITY_LIST;
-    }
-
-    public static List<VoxelShape> getVoxelShapeList() {
-        VOXEL_SHAPE_LIST.clear();
-        return VOXEL_SHAPE_LIST;
-    }
-
-    public static List<AABB> getAABBList() {
-        AABB_LIST.clear();
-        return AABB_LIST;
     }
 }


### PR DESCRIPTION
Provides thread-local reusable ArrayList buffers for Entity, VoxelShape, and AABB collections. Each get method clears and returns the thread-local list, eliminating per-call ArrayList allocations in hot entity query paths.