### PR TITLE
Use squared distance checks

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/ai/goal/FollowPlayerRiddenEntityGoal.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/ai/goal/FollowPlayerRiddenEntityGoal.java.patch
@@ -1,0 +1,24 @@
+--- a/net/minecraft/world/entity/ai/goal/FollowPlayerRiddenEntityGoal.java
++++ b/net/minecraft/world/entity/ai/goal/FollowPlayerRiddenEntityGoal.java
+@@ -75,7 +_,9 @@
+                 BlockPos behindEntityPos = this.following.blockPosition().relative(this.following.getDirection().getOpposite());
+                 behindEntityPos = behindEntityPos.offset(0, -1, 0);
+                 this.mob.getNavigation().moveTo(behindEntityPos.getX(), behindEntityPos.getY(), behindEntityPos.getZ(), 1.0);
+-                if (this.mob.distanceTo(this.following) < 4.0F) {
++                // Gale start - use squared distance checks
++                if (this.mob.distanceToSqr(this.following) < 4.0F * 4.0F) {
++                // Gale end - use squared distance checks
+                     this.timeToRecalcPath = 0;
+                     this.currentGoal = FollowPlayerRiddenEntityGoal.FollowEntityGoal.GO_IN_ENTITY_DIRECTION;
+                 }
+@@ -83,7 +_,9 @@
+                 Direction direction = this.following.getMotionDirection();
+                 BlockPos goTo = this.following.blockPosition().relative(direction, 10);
+                 this.mob.getNavigation().moveTo(goTo.getX(), goTo.getY() - 1, goTo.getZ(), 1.0);
+-                if (this.mob.distanceTo(this.following) > 12.0F) {
++                // Gale start - use squared distance checks
++                if (this.mob.distanceToSqr(this.following) > 12.0F * 12.0F) {
++                // Gale end - use squared distance checks
+                     this.timeToRecalcPath = 0;
+                     this.currentGoal = FollowPlayerRiddenEntityGoal.FollowEntityGoal.GO_TO_ENTITY;
+                 }

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/bee/Bee.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/animal/bee/Bee.java.patch
@@ -1,0 +1,24 @@
+--- a/net/minecraft/world/entity/animal/bee/Bee.java
++++ b/net/minecraft/world/entity/animal/bee/Bee.java
+@@ -1191,7 +_,9 @@
+                     Bee.this.remainingCooldownBeforeLocatingNewFlower = 200;
+                 } else if (Bee.this.savedFlowerPos != null) { // Paper - add null check since API can manipulate this
+                     Vec3 flowerPos = Vec3.atBottomCenterOf(Bee.this.savedFlowerPos).add(0.0, 0.6F, 0.0);
+-                    if (flowerPos.distanceTo(Bee.this.position()) > 1.0) {
++                    // Gale start - use squared distance checks
++                    if (flowerPos.distanceToSqr(Bee.this.position()) > 1.0) {
++                    // Gale end - use squared distance checks
+                         this.hoverPos = flowerPos;
+                         this.setWantedPos();
+                     } else {
+@@ -1199,7 +_,9 @@
+                             this.hoverPos = flowerPos;
+                         }
+ 
+-                        boolean arrivedAtHoverPos = Bee.this.position().distanceTo(this.hoverPos) <= 0.1;
++                        // Gale start - use squared distance checks
++                        boolean arrivedAtHoverPos = Bee.this.position().distanceToSqr(this.hoverPos) <= 0.1 * 0.1;
++                        // Gale end - use squared distance checks
+                         boolean shouldSetWantedPos = true;
+                         if (!arrivedAtHoverPos && this.pollinatingTicks > 600) {
+                             Bee.this.dropFlower();

--- a/gale-server/minecraft-patches/sources/net/minecraft/world/entity/vehicle/minecart/NewMinecartBehavior.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/world/entity/vehicle/minecart/NewMinecartBehavior.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/entity/vehicle/minecart/NewMinecartBehavior.java
++++ b/net/minecraft/world/entity/vehicle/minecart/NewMinecartBehavior.java
+@@ -461,7 +_,9 @@
+             }
+         }
+ 
+-        if (this.position().distanceTo(oldPosition) < 1.0E-5F && newPosition.distanceTo(oldPosition) > 1.0E-5F) {
++        // Gale start - use squared distance checks
++        if (this.position().distanceToSqr(oldPosition) < 1.0E-5F * 1.0E-5F && newPosition.distanceToSqr(oldPosition) > 1.0E-5F * 1.0E-5F) {
++        // Gale end - use squared distance checks
+             this.setDeltaMovement(Vec3.ZERO);
+             return 0.0;
+         } else {


### PR DESCRIPTION
A few places were using `distanceTo(...)` only for simple threshold comparisons.

This switches those checks to `distanceToSqr(...)` with squared thresholds, which avoids the unnecessary square root while preserving the existing logic.

Affected areas:
- bee pollination hover checks
- FollowPlayerRiddenEntityGoal distance checks
- minecart near-zero movement check

No functional changes intended.
