### PR TITLE
add rambar and tpsbar command

### DIFF
--- a/gale-server/minecraft-patches/sources/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/gale-server/minecraft-patches/sources/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -13,6 +13,15 @@
          // Paper end - initialize global and world-defaults configuration
          this.server.spark.enableEarlyIfRequested(); // Paper - spark
          // Paper start - fix converting txt to json file; convert old users earlier after PlayerList creation but before file load/save
+@@ -248,6 +_,8 @@
+         org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash); // Paper - start watchdog thread
+         consoleThread.start(); // Paper - Enhance console tab completions for brigadier commands; start console thread after MinecraftServer.console & PaperConfig are initialized
+         io.papermc.paper.command.PaperCommands.registerCommands(this); // Paper - setup /paper command
++        org.galemc.gale.command.GaleCommands.registerCommands(this); // Gale - Gale commands
++        org.galemc.gale.task.BossBarTask.startAll(); // Gale - TPS bar and RAM bar
+         this.server.spark.registerCommandBeforePlugins(this.server); // Paper - spark
+         com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics(); // Paper - start metrics
+         com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // Paper - load version history now
 @@ -402,7 +_,7 @@
      @Override
      protected void tickServer(final BooleanSupplier haveTime) {
@@ -21,6 +30,14 @@
 +        if (org.galemc.gale.async.SimulationFlag.REAL) if (this.jsonRpcServer != null) { // Gale - Speculative execution based on next tick simulation - Simulate next tick
              this.jsonRpcServer.tick();
          }
+     }
+@@ -906,6 +_,7 @@
+     @Override
+     protected void stopServer() {
+         this.notificationManager().serverShuttingDown();
++        org.galemc.gale.task.BossBarTask.stopAll(); // Gale - TPS bar and RAM bar
+         super.stopServer();
+         //Util.shutdownExecutors(); // Paper - Improved watchdog support; moved into super
      }
 @@ -917,7 +_,11 @@
  

--- a/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java.patch
+++ b/gale-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java.patch
@@ -1,0 +1,10 @@
+--- a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
+@@ -5,6 +_,7 @@
+ 
+ public final class CraftDefaultPermissions {
+     private static final String ROOT = "minecraft";
++    public static final String GALE_ROOT = "gale"; // Gale - set Gale permissions root
+ 
+     private CraftDefaultPermissions() {}
+ 

--- a/gale-server/src/main/java/org/galemc/gale/command/GaleCommand.java
+++ b/gale-server/src/main/java/org/galemc/gale/command/GaleCommand.java
@@ -1,0 +1,150 @@
+package org.galemc.gale.command;
+
+import io.papermc.paper.command.CommandUtil;
+import it.unimi.dsi.fastutil.Pair;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.minecraft.util.Util;
+import org.galemc.gale.command.subcommands.RamBarCommand;
+import org.galemc.gale.command.subcommands.TpsBarCommand;
+import org.jspecify.annotations.Nullable;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+import org.bukkit.plugin.PluginManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class GaleCommand extends Command {
+
+    public static final String COMMAND_LABEL = "gale";
+    public static final String BASE_PERM = GaleCommands.COMMAND_BASE_PERM + "." + COMMAND_LABEL;
+    private static final Permission basePermission = new Permission(BASE_PERM, PermissionDefault.OP);
+    // subcommand label -> subcommand
+    private static final GaleSubcommand TPS_BAR_SUBCOMMAND = new TpsBarCommand();
+    private static final GaleSubcommand RAM_BAR_SUBCOMMAND = new RamBarCommand();
+    private static final Map<String, GaleSubcommand> SUBCOMMANDS = Util.make(() -> {
+        final Map<Set<String>, GaleSubcommand> commands = new HashMap<>();
+
+        commands.put(Set.of(TpsBarCommand.LITERAL_ARGUMENT), TPS_BAR_SUBCOMMAND);
+        commands.put(Set.of(RamBarCommand.LITERAL_ARGUMENT), RAM_BAR_SUBCOMMAND);
+
+        return commands.entrySet().stream()
+            .flatMap(entry -> entry.getKey().stream().map(s -> Map.entry(s, entry.getValue())))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    });
+
+    private String createUsageMessage(Collection<String> arguments) {
+        return "/" + COMMAND_LABEL + " [" + String.join(" | ", arguments) + "]";
+    }
+
+    public GaleCommand() {
+        super(COMMAND_LABEL);
+        this.description = "Gale related commands";
+        this.usageMessage = this.createUsageMessage(SUBCOMMANDS.keySet());
+        final List<Permission> permissions = SUBCOMMANDS.values().stream().map(GaleSubcommand::getPermission).filter(Objects::nonNull).toList();
+        this.setPermission(BASE_PERM);
+        final PluginManager pluginManager = Bukkit.getServer().getPluginManager();
+        pluginManager.addPermission(basePermission);
+        for (final Permission permission : permissions) {
+            pluginManager.addPermission(permission);
+        }
+    }
+
+    @Override
+    public List<String> tabComplete(
+        final CommandSender sender,
+        final String alias,
+        final String[] args,
+        final @Nullable Location location
+    ) throws IllegalArgumentException {
+        if (args.length <= 1) {
+            List<String> subCommandArguments = new ArrayList<>(SUBCOMMANDS.size());
+
+            for (Map.Entry<String, GaleSubcommand> subCommandEntry : SUBCOMMANDS.entrySet()) {
+                if (subCommandEntry.getValue().testPermission(sender)) {
+                    subCommandArguments.add(subCommandEntry.getKey());
+                }
+            }
+
+            return CommandUtil.getListMatchingLast(sender, args, subCommandArguments);
+        }
+
+        final Pair<String, GaleSubcommand> subCommand = resolveCommand(args[0]);
+
+        if (subCommand != null && subCommand.second().testPermission(sender)) {
+            return subCommand.second().tabComplete(sender, subCommand.first(), Arrays.copyOfRange(args, 1, args.length));
+        }
+
+        return Collections.emptyList();
+    }
+
+    private boolean testHasOnePermission(CommandSender sender) {
+        for (Map.Entry<String, GaleSubcommand> subCommandEntry : SUBCOMMANDS.entrySet()) {
+            if (subCommandEntry.getValue().testPermission(sender)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean execute(
+        final CommandSender sender,
+        final String commandLabel,
+        final String[] args
+    ) {
+        // Check if the sender has the base permission and at least one specific permission
+        if (!sender.hasPermission(basePermission) || !this.testHasOnePermission(sender)) {
+            sender.sendMessage(Bukkit.permissionMessage());
+            return true;
+        }
+
+        // Determine the usage message with the subcommands they can perform
+        List<String> subCommandArguments = new ArrayList<>(SUBCOMMANDS.size());
+        for (Map.Entry<String, GaleSubcommand> subCommandEntry : SUBCOMMANDS.entrySet()) {
+            if (subCommandEntry.getValue().testPermission(sender)) {
+                subCommandArguments.add(subCommandEntry.getKey());
+            }
+        }
+
+        String specificUsageMessage = this.createUsageMessage(subCommandArguments);
+
+        // If they did not give a subcommand
+        if (args.length == 0) {
+            sender.sendMessage(Component.text("Command usage: " + specificUsageMessage, NamedTextColor.GRAY));
+            return false;
+        }
+
+        // If they do not have permission for the subcommand they gave, or the argument is not a valid subcommand
+        final Pair<String, GaleSubcommand> subCommand = resolveCommand(args[0]);
+        if (subCommand == null || !subCommand.second().testPermission(sender)) {
+            sender.sendMessage(Component.text("Usage: " + specificUsageMessage, NamedTextColor.RED));
+            return false;
+        }
+
+        // Execute the subcommand
+        final String[] choppedArgs = Arrays.copyOfRange(args, 1, args.length);
+        return subCommand.second().execute(sender, subCommand.first(), choppedArgs);
+
+    }
+
+    private static @Nullable Pair<String, GaleSubcommand> resolveCommand(String label) {
+        label = label.toLowerCase(Locale.ENGLISH);
+        return SUBCOMMANDS.containsKey(label) ? Pair.of(label, SUBCOMMANDS.get(label)) : null;
+    }
+}

--- a/gale-server/src/main/java/org/galemc/gale/command/GaleCommands.java
+++ b/gale-server/src/main/java/org/galemc/gale/command/GaleCommands.java
@@ -1,0 +1,26 @@
+package org.galemc.gale.command;
+
+import net.minecraft.server.MinecraftServer;
+import org.bukkit.command.Command;
+import org.bukkit.craftbukkit.util.permissions.CraftDefaultPermissions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class GaleCommands {
+
+    public static final String COMMAND_BASE_PERM = CraftDefaultPermissions.GALE_ROOT + ".command";
+
+    private GaleCommands() {
+    }
+
+    private static final Map<String, Command> COMMANDS = new HashMap<>();
+
+    static {
+        COMMANDS.put(GaleCommand.COMMAND_LABEL, new GaleCommand());
+    }
+
+    public static void registerCommands(final MinecraftServer server) {
+        COMMANDS.forEach((s, command) -> server.server.getCommandMap().register(s, "Gale", command));
+    }
+}

--- a/gale-server/src/main/java/org/galemc/gale/command/GaleSubcommand.java
+++ b/gale-server/src/main/java/org/galemc/gale/command/GaleSubcommand.java
@@ -1,0 +1,20 @@
+package org.galemc.gale.command;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.permissions.Permission;
+
+import java.util.Collections;
+import java.util.List;
+
+public interface GaleSubcommand {
+
+    boolean execute(CommandSender sender, String subCommand, String[] args);
+
+    default List<String> tabComplete(final CommandSender sender, final String subCommand, final String[] args) {
+        return Collections.emptyList();
+    }
+
+    boolean testPermission(CommandSender sender);
+
+    Permission getPermission();
+}

--- a/gale-server/src/main/java/org/galemc/gale/command/PermissionedGaleSubcommand.java
+++ b/gale-server/src/main/java/org/galemc/gale/command/PermissionedGaleSubcommand.java
@@ -1,0 +1,28 @@
+package org.galemc.gale.command;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+
+public abstract class PermissionedGaleSubcommand implements GaleSubcommand {
+
+    private final Permission permission;
+
+    protected PermissionedGaleSubcommand(Permission permission) {
+        this.permission = permission;
+    }
+
+    protected PermissionedGaleSubcommand(String permission, PermissionDefault permissionDefault) {
+        this(new Permission(permission, permissionDefault));
+    }
+
+    @Override
+    public boolean testPermission(CommandSender sender) {
+        return sender.hasPermission(this.permission);
+    }
+
+    @Override
+    public Permission getPermission() {
+        return this.permission;
+    }
+}

--- a/gale-server/src/main/java/org/galemc/gale/command/package-info.java
+++ b/gale-server/src/main/java/org/galemc/gale/command/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.galemc.gale.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/gale-server/src/main/java/org/galemc/gale/command/subcommands/RamBarCommand.java
+++ b/gale-server/src/main/java/org/galemc/gale/command/subcommands/RamBarCommand.java
@@ -1,0 +1,40 @@
+package org.galemc.gale.command.subcommands;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionDefault;
+import org.galemc.gale.command.GaleCommand;
+import org.galemc.gale.command.PermissionedGaleSubcommand;
+import org.galemc.gale.task.RAMBarTask;
+
+import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+
+public final class RamBarCommand extends PermissionedGaleSubcommand {
+
+    public static final String LITERAL_ARGUMENT = "rambar";
+    public static final String PERM = GaleCommand.BASE_PERM + "." + LITERAL_ARGUMENT;
+
+    public RamBarCommand() {
+        super(PERM, PermissionDefault.OP);
+    }
+
+    @Override
+    public boolean execute(final CommandSender sender, final String subCommand, final String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(Component.text("Only players can toggle the RAM bar.", RED));
+            return true;
+        }
+
+        boolean result = RAMBarTask.instance().togglePlayer(player);
+        Component output = MiniMessage.miniMessage().deserialize(RAMBarTask.RAMBAR_COMMAND_OUTPUT,
+                Placeholder.component("onoff", Component.translatable(result ? "options.on" : "options.off")
+                        .color(result ? GREEN : RED)),
+                Placeholder.parsed("target", player.getName()));
+        sender.sendMessage(output);
+        return true;
+    }
+}

--- a/gale-server/src/main/java/org/galemc/gale/command/subcommands/TpsBarCommand.java
+++ b/gale-server/src/main/java/org/galemc/gale/command/subcommands/TpsBarCommand.java
@@ -1,0 +1,40 @@
+package org.galemc.gale.command.subcommands;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionDefault;
+import org.galemc.gale.command.GaleCommand;
+import org.galemc.gale.command.PermissionedGaleSubcommand;
+import org.galemc.gale.task.TPSBarTask;
+
+import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+
+public final class TpsBarCommand extends PermissionedGaleSubcommand {
+
+    public static final String LITERAL_ARGUMENT = "tpsbar";
+    public static final String PERM = GaleCommand.BASE_PERM + "." + LITERAL_ARGUMENT;
+
+    public TpsBarCommand() {
+        super(PERM, PermissionDefault.OP);
+    }
+
+    @Override
+    public boolean execute(final CommandSender sender, final String subCommand, final String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(Component.text("Only players can toggle the TPS bar.", RED));
+            return true;
+        }
+
+        boolean result = TPSBarTask.instance().togglePlayer(player);
+        Component output = MiniMessage.miniMessage().deserialize(TPSBarTask.TPSBAR_COMMAND_OUTPUT,
+                Placeholder.component("onoff", Component.translatable(result ? "options.on" : "options.off")
+                        .color(result ? GREEN : RED)),
+                Placeholder.parsed("target", player.getName()));
+        sender.sendMessage(output);
+        return true;
+    }
+}

--- a/gale-server/src/main/java/org/galemc/gale/command/subcommands/package-info.java
+++ b/gale-server/src/main/java/org/galemc/gale/command/subcommands/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.galemc.gale.command.subcommands;
+
+import org.jspecify.annotations.NullMarked;

--- a/gale-server/src/main/java/org/galemc/gale/task/BossBarTask.java
+++ b/gale-server/src/main/java/org/galemc/gale/task/BossBarTask.java
@@ -1,0 +1,99 @@
+package org.galemc.gale.task;
+
+import net.kyori.adventure.bossbar.BossBar;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.galemc.gale.util.MinecraftInternalPlugin;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+
+public abstract class BossBarTask extends BukkitRunnable {
+    private final Map<UUID, BossBar> bossbars = new HashMap<>();
+    private boolean started;
+
+    abstract BossBar createBossBar();
+
+    abstract void updateBossBar(BossBar bossbar, Player player);
+
+    @Override
+    public void run() {
+        Iterator<Map.Entry<UUID, BossBar>> iter = bossbars.entrySet().iterator();
+        while (iter.hasNext()) {
+            Map.Entry<UUID, BossBar> entry = iter.next();
+            Player player = Bukkit.getPlayer(entry.getKey());
+            if (player == null) {
+                iter.remove();
+                continue;
+            }
+            updateBossBar(entry.getValue(), player);
+        }
+    }
+
+    @Override
+    public void cancel() {
+        super.cancel();
+        new HashSet<>(this.bossbars.keySet()).forEach(uuid -> {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null) {
+                removePlayer(player);
+            }
+        });
+        this.bossbars.clear();
+    }
+
+    public boolean removePlayer(Player player) {
+        BossBar bossbar = this.bossbars.remove(player.getUniqueId());
+        if (bossbar != null) {
+            player.hideBossBar(bossbar);
+            return true;
+        }
+        return false;
+    }
+
+    public void addPlayer(Player player) {
+        removePlayer(player);
+        BossBar bossbar = createBossBar();
+        this.bossbars.put(player.getUniqueId(), bossbar);
+        this.updateBossBar(bossbar, player);
+        player.showBossBar(bossbar);
+    }
+
+    public boolean hasPlayer(UUID uuid) {
+        return this.bossbars.containsKey(uuid);
+    }
+
+    public boolean togglePlayer(Player player) {
+        if (removePlayer(player)) {
+            return false;
+        }
+        addPlayer(player);
+        return true;
+    }
+
+    public void start() {
+        stop();
+        this.runTaskTimerAsynchronously(new MinecraftInternalPlugin(), 1, 1);
+        started = true;
+    }
+
+    public void stop() {
+        if (started) {
+            cancel();
+        }
+    }
+
+    public static void startAll() {
+        RAMBarTask.instance().start();
+        TPSBarTask.instance().start();
+    }
+
+    public static void stopAll() {
+        RAMBarTask.instance().stop();
+        TPSBarTask.instance().stop();
+    }
+}

--- a/gale-server/src/main/java/org/galemc/gale/task/RAMBarTask.java
+++ b/gale-server/src/main/java/org/galemc/gale/task/RAMBarTask.java
@@ -1,0 +1,128 @@
+package org.galemc.gale.task;
+
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.entity.Player;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryUsage;
+
+public class RAMBarTask extends BossBarTask {
+    public static final String RAMBAR_COMMAND_OUTPUT = "<green>Rambar toggled <onoff> for <target>";
+
+    public static final String COMMAND_RAM_BAR_TITLE = "<gray>Ram<yellow>:</yellow> <used>/<xmx> (<percent>)";
+    public static final BossBar.Overlay COMMAND_RAM_BAR_PROGRESS_OVERLAY = BossBar.Overlay.NOTCHED_20;
+    public static final BossBar.Color COMMAND_RAM_BAR_PROGRESS_COLOR_GOOD = BossBar.Color.GREEN;
+    public static final BossBar.Color COMMAND_RAM_BAR_PROGRESS_COLOR_MEDIUM = BossBar.Color.YELLOW;
+    public static final BossBar.Color COMMAND_RAM_BAR_PROGRESS_COLOR_LOW = BossBar.Color.RED;
+    public static final String COMMAND_RAM_BAR_TEXT_COLOR_GOOD = "<gradient:#55ff55:#00aa00><text></gradient>";
+    public static final String COMMAND_RAM_BAR_TEXT_COLOR_MEDIUM = "<gradient:#ffff55:#ffaa00><text></gradient>";
+    public static final String COMMAND_RAM_BAR_TEXT_COLOR_LOW = "<gradient:#ff5555:#aa0000><text></gradient>";
+    public static final int COMMAND_RAM_BAR_TICK_INTERVAL = 20;
+
+    private static RAMBarTask instance;
+    private long allocated = 0L;
+    private long used = 0L;
+    private long xmx = 0L;
+    private long xms = 0L;
+    private float percent = 0F;
+    private int tick = 0;
+
+    public static RAMBarTask instance() {
+        if (instance == null) {
+            instance = new RAMBarTask();
+        }
+        return instance;
+    }
+
+    @Override
+    BossBar createBossBar() {
+        return BossBar.bossBar(Component.text(""), 0.0F, instance().getBossBarColor(), COMMAND_RAM_BAR_PROGRESS_OVERLAY);
+    }
+
+    @Override
+    void updateBossBar(BossBar bossbar, Player player) {
+        bossbar.progress(getBossBarProgress());
+        bossbar.color(getBossBarColor());
+        bossbar.name(MiniMessage.miniMessage().deserialize(COMMAND_RAM_BAR_TITLE,
+                Placeholder.component("allocated", format(this.allocated)),
+                Placeholder.component("used", format(this.used)),
+                Placeholder.component("xmx", format(this.xmx)),
+                Placeholder.component("xms", format(this.xms)),
+                Placeholder.unparsed("percent", ((int) (this.percent * 100)) + "%")
+        ));
+    }
+
+    @Override
+    public void run() {
+        if (++this.tick < COMMAND_RAM_BAR_TICK_INTERVAL) {
+            return;
+        }
+        this.tick = 0;
+
+        MemoryUsage heap = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
+
+        this.allocated = heap.getCommitted();
+        this.used = heap.getUsed();
+        this.xmx = heap.getMax();
+        this.xms = heap.getInit();
+        this.percent = Math.max(Math.min((float) this.used / this.xmx, 1.0F), 0.0F);
+
+        super.run();
+    }
+
+    private float getBossBarProgress() {
+        return this.percent;
+    }
+
+    private BossBar.Color getBossBarColor() {
+        if (this.percent < 0.5F) {
+            return COMMAND_RAM_BAR_PROGRESS_COLOR_GOOD;
+        } else if (this.percent < 0.75F) {
+            return COMMAND_RAM_BAR_PROGRESS_COLOR_MEDIUM;
+        } else {
+            return COMMAND_RAM_BAR_PROGRESS_COLOR_LOW;
+        }
+    }
+
+    public Component format(long v) {
+        String color;
+        if (this.percent < 0.60F) {
+            color = COMMAND_RAM_BAR_TEXT_COLOR_GOOD;
+        } else if (this.percent < 0.85F) {
+            color = COMMAND_RAM_BAR_TEXT_COLOR_MEDIUM;
+        } else {
+            color = COMMAND_RAM_BAR_TEXT_COLOR_LOW;
+        }
+        String value;
+        if (v < 1024) {
+            value = v + "B";
+        } else {
+            int z = (63 - Long.numberOfLeadingZeros(v)) / 10;
+            value = String.format("%.1f%s", (double) v / (1L << (z * 10)), "BKMGTPE".charAt(z));
+        }
+        return MiniMessage.miniMessage().deserialize(color, Placeholder.unparsed("text", value));
+    }
+
+    public long getAllocated() {
+        return this.allocated;
+    }
+
+    public long getUsed() {
+        return this.used;
+    }
+
+    public long getXmx() {
+        return this.xmx;
+    }
+
+    public long getXms() {
+        return this.xms;
+    }
+
+    public float getPercent() {
+        return this.percent;
+    }
+}

--- a/gale-server/src/main/java/org/galemc/gale/task/TPSBarTask.java
+++ b/gale-server/src/main/java/org/galemc/gale/task/TPSBarTask.java
@@ -1,0 +1,154 @@
+package org.galemc.gale.task;
+
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class TPSBarTask extends BossBarTask {
+    public static final String TPSBAR_COMMAND_OUTPUT = "<green>Tpsbar toggled <onoff> for <target>";
+
+    public static final String COMMAND_TPS_BAR_TITLE = "<gray>TPS<yellow>:</yellow> <tps> MSPT<yellow>:</yellow> <mspt> Ping<yellow>:</yellow> <ping>ms";
+    public static final BossBar.Overlay COMMAND_TPS_BAR_PROGRESS_OVERLAY = BossBar.Overlay.NOTCHED_20;
+    public static final TPSBarTask.FillMode COMMAND_TPS_BAR_PROGRESS_FILL_MODE = TPSBarTask.FillMode.MSPT;
+    public static final BossBar.Color COMMAND_TPS_BAR_PROGRESS_COLOR_GOOD = BossBar.Color.GREEN;
+    public static final BossBar.Color COMMAND_TPS_BAR_PROGRESS_COLOR_MEDIUM = BossBar.Color.YELLOW;
+    public static final BossBar.Color COMMAND_TPS_BAR_PROGRESS_COLOR_LOW = BossBar.Color.RED;
+    public static final String COMMAND_TPS_BAR_TEXT_COLOR_GOOD = "<gradient:#55ff55:#00aa00><text></gradient>";
+    public static final String COMMAND_TPS_BAR_TEXT_COLOR_MEDIUM = "<gradient:#ffff55:#ffaa00><text></gradient>";
+    public static final String COMMAND_TPS_BAR_TEXT_COLOR_LOW = "<gradient:#ff5555:#aa0000><text></gradient>";
+    public static final int COMMAND_TPS_BAR_TICK_INTERVAL = 20;
+
+    private static TPSBarTask instance;
+    private double tps = 20.0D;
+    private double mspt = 0.0D;
+    private int tick = 0;
+
+    public static TPSBarTask instance() {
+        if (instance == null) {
+            instance = new TPSBarTask();
+        }
+        return instance;
+    }
+
+    @Override
+    BossBar createBossBar() {
+        return BossBar.bossBar(Component.text(""), 0.0F, instance().getBossBarColor(), COMMAND_TPS_BAR_PROGRESS_OVERLAY);
+    }
+
+    @Override
+    void updateBossBar(BossBar bossbar, Player player) {
+        bossbar.progress(getBossBarProgress());
+        bossbar.color(getBossBarColor());
+        bossbar.name(MiniMessage.miniMessage().deserialize(COMMAND_TPS_BAR_TITLE,
+                Placeholder.component("tps", getTPSColor()),
+                Placeholder.component("mspt", getMSPTColor()),
+                Placeholder.component("ping", getPingColor(player.getPing()))
+        ));
+    }
+
+    @Override
+    public void run() {
+        if (++tick < COMMAND_TPS_BAR_TICK_INTERVAL) {
+            return;
+        }
+        tick = 0;
+
+        this.tps = Math.max(Math.min(Bukkit.getTPS()[0], 20.0D), 0.0D);
+        this.mspt = Bukkit.getAverageTickTime();
+
+        super.run();
+    }
+
+    private float getBossBarProgress() {
+        if (COMMAND_TPS_BAR_PROGRESS_FILL_MODE == FillMode.MSPT) {
+            return Math.max(Math.min((float) mspt / 50.0F, 1.0F), 0.0F);
+        } else {
+            return Math.max(Math.min((float) tps / 20.0F, 1.0F), 0.0F);
+        }
+    }
+
+    private BossBar.Color getBossBarColor() {
+        if (isGood(COMMAND_TPS_BAR_PROGRESS_FILL_MODE)) {
+            return COMMAND_TPS_BAR_PROGRESS_COLOR_GOOD;
+        } else if (isMedium(COMMAND_TPS_BAR_PROGRESS_FILL_MODE)) {
+            return COMMAND_TPS_BAR_PROGRESS_COLOR_MEDIUM;
+        } else {
+            return COMMAND_TPS_BAR_PROGRESS_COLOR_LOW;
+        }
+    }
+
+    private boolean isGood(FillMode mode) {
+        return isGood(mode, 0);
+    }
+
+    private boolean isGood(FillMode mode, int ping) {
+        if (mode == FillMode.MSPT) {
+            return mspt < 40;
+        } else if (mode == FillMode.TPS) {
+            return tps >= 19;
+        } else if (mode == FillMode.PING) {
+            return ping < 100;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isMedium(FillMode mode) {
+        return isMedium(mode, 0);
+    }
+
+    private boolean isMedium(FillMode mode, int ping) {
+        if (mode == FillMode.MSPT) {
+            return mspt < 50;
+        } else if (mode == FillMode.TPS) {
+            return tps >= 15;
+        } else if (mode == FillMode.PING) {
+            return ping < 200;
+        } else {
+            return false;
+        }
+    }
+
+    private Component getTPSColor() {
+        String color;
+        if (isGood(FillMode.TPS)) {
+            color = COMMAND_TPS_BAR_TEXT_COLOR_GOOD;
+        } else if (isMedium(FillMode.TPS)) {
+            color = COMMAND_TPS_BAR_TEXT_COLOR_MEDIUM;
+        } else {
+            color = COMMAND_TPS_BAR_TEXT_COLOR_LOW;
+        }
+        return MiniMessage.miniMessage().deserialize(color, Placeholder.parsed("text", String.format("%.2f", tps)));
+    }
+
+    private Component getMSPTColor() {
+        String color;
+        if (isGood(FillMode.MSPT)) {
+            color = COMMAND_TPS_BAR_TEXT_COLOR_GOOD;
+        } else if (isMedium(FillMode.MSPT)) {
+            color = COMMAND_TPS_BAR_TEXT_COLOR_MEDIUM;
+        } else {
+            color = COMMAND_TPS_BAR_TEXT_COLOR_LOW;
+        }
+        return MiniMessage.miniMessage().deserialize(color, Placeholder.parsed("text", String.format("%.2f", mspt)));
+    }
+
+    private Component getPingColor(int ping) {
+        String color;
+        if (isGood(FillMode.PING, ping)) {
+            color = COMMAND_TPS_BAR_TEXT_COLOR_GOOD;
+        } else if (isMedium(FillMode.PING, ping)) {
+            color = COMMAND_TPS_BAR_TEXT_COLOR_MEDIUM;
+        } else {
+            color = COMMAND_TPS_BAR_TEXT_COLOR_LOW;
+        }
+        return MiniMessage.miniMessage().deserialize(color, Placeholder.parsed("text", String.format("%s", ping)));
+    }
+
+    public enum FillMode {
+        TPS, MSPT, PING
+    }
+}

--- a/gale-server/src/main/java/org/galemc/gale/util/MinecraftInternalPlugin.java
+++ b/gale-server/src/main/java/org/galemc/gale/util/MinecraftInternalPlugin.java
@@ -1,0 +1,155 @@
+package org.galemc.gale.util;
+
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventManager;
+import org.bukkit.Server;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.generator.BiomeProvider;
+import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginBase;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.PluginLoader;
+import org.bukkit.plugin.PluginLogger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.List;
+
+public class MinecraftInternalPlugin extends PluginBase {
+    private boolean enabled = true;
+
+    private final String pluginName;
+    private PluginDescriptionFile pdf;
+
+    public MinecraftInternalPlugin() {
+        this.pluginName = "Minecraft";
+        pdf = new PluginDescriptionFile(pluginName, "1.0", "nms");
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public File getDataFolder() {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public PluginDescriptionFile getDescription() {
+        return pdf;
+    }
+
+    @Override
+    public io.papermc.paper.plugin.configuration.PluginMeta getPluginMeta() {
+        return pdf;
+    }
+
+    @Override
+    public FileConfiguration getConfig() {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public InputStream getResource(String filename) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void saveConfig() {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void saveDefaultConfig() {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void saveResource(String resourcePath, boolean replace) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void reloadConfig() {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public PluginLogger getLogger() {
+        return new PluginLogger(this);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        return false;
+    }
+
+    @Override
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        return null;
+    }
+
+    @Override
+    public LifecycleEventManager<Plugin> getLifecycleManager() {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void onLoad() {
+    }
+
+    @Override
+    public void onEnable() {
+    }
+
+    @Override
+    public void onDisable() {
+    }
+
+    @Override
+    public Server getServer() {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public boolean isNaggable() {
+        return false;
+    }
+
+    @Override
+    public void setNaggable(boolean naggable) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public PluginLoader getPluginLoader() {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Nullable
+    @Override
+    public BiomeProvider getDefaultBiomeProvider(@NotNull String worldName, @Nullable String id) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Nullable
+    @Override
+    public ChunkGenerator getDefaultWorldGenerator(@NotNull String worldName, @Nullable String id) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public String toString() {
+        return "MinecraftInternalPlugin{pluginName='" + this.pluginName + "', pdfVersion=" + this.pdf.getVersion() + "}";
+    }
+}


### PR DESCRIPTION
Adds /gale command with tpsbar and rambar subcommands:

- /gale tpsbar toggles a boss bar showing TPS, MSPT and ping with MiniMessage gradient text colors and NOTCHED_20 progress
- /gale rambar toggles a boss bar showing used/max heap memory with percent-based color thresholds
- Permissions: gale.command.gale.tpsbar and gale.command.gale.rambar, default OP, hidden from tab completion without permission
- Command registered through the Bukkit CommandMap next to PaperCommands.registerCommands, following the existing subcommand framework pattern
- Adds BossBarTask, TPSBarTask and RAMBarTask under org.galemc.gale.task plus MinecraftInternalPlugin for scheduler access
- CraftDefaultPermissions gains GALE_ROOT for the permission tree